### PR TITLE
Add compatibility with react native cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,12 @@
   "types": "./cjs/index.d.ts",
   "module": "./esm/index.js",
   "exports": {
+    ".": {
     "import": "./esm/index.js",
     "require": "./cjs/index.js",
     "default": "./umd/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "browser": "./umd/index.js",
   "jsdelivr": "./umd/index.js",


### PR DESCRIPTION
Hello there!
It seems to allow compatibility with react-native-cli you need to self reference the package.json in the package.json. Check out this issue: https://github.com/react-native-community/cli/issues/1168. 

I'd really appreciate if this could be added!