### PR TITLE
fix: Interpret `max-age=0` as a valid `cache-control` header

### DIFF
--- a/src/header/interpreter.ts
+++ b/src/header/interpreter.ts
@@ -28,7 +28,7 @@ export const defaultHeaderInterpreter: HeadersInterpreter = (headers) => {
       return 0;
     }
 
-    if (maxAge) {
+    if (maxAge !== undefined) {
       const age = headers[Header.Age];
 
       if (!age) {

--- a/test/header/cache-control.test.ts
+++ b/test/header/cache-control.test.ts
@@ -30,4 +30,13 @@ describe('test Cache-Control header', () => {
     // 10 Seconds in milliseconds
     expect(result).toBe(10 * 1000);
   });
+
+  it('tests with max-age of 0', () => {
+    const result = defaultHeaderInterpreter({
+      [Header.CacheControl]: 'max-age=0'
+    })
+
+    expect(result).toBe(0);
+    expect(result).not.toBe('not enough headers')
+  })
 });

--- a/test/header/cache-control.test.ts
+++ b/test/header/cache-control.test.ts
@@ -34,9 +34,9 @@ describe('test Cache-Control header', () => {
   it('tests with max-age of 0', () => {
     const result = defaultHeaderInterpreter({
       [Header.CacheControl]: 'max-age=0'
-    })
+    });
 
     expect(result).toBe(0);
-    expect(result).not.toBe('not enough headers')
-  })
+    expect(result).not.toBe('not enough headers');
+  });
 });


### PR DESCRIPTION
Hi! I was dealing with an API that sends `cache-control: max-age=0, public` and noticed that the header interpreter treats `maxAge == 0 == false` --> `'not enough headers'`.