### PR TITLE
fix: Prevent response storage calls if method is not supported

### DIFF
--- a/src/interceptors/response.ts
+++ b/src/interceptors/response.ts
@@ -45,8 +45,9 @@ export function defaultResponseInterceptor(
       return response;
     }
 
+    const config = response.config;
     // Request interceptor merges defaults with per request configuration
-    const cacheConfig = response.config.cache as CacheProperties;
+    const cacheConfig = config.cache as CacheProperties;
 
     // Skip cache: either false or weird behavior
     // config.cache should always exists, at least from global config merge.
@@ -61,8 +62,17 @@ export function defaultResponseInterceptor(
 
       return { ...response, cached: false };
     }
+    
+    if (!isMethodIn(config.method, cacheConfig.methods)) {
+      if (__ACI_DEV__) {
+        axios.debug?.({
+          msg: `Ignored because method (${config.method}) is not in cache.methods (${cacheConfig.methods})`
+        });
+      }
 
-    const config = response.config;
+      return response;
+    }
+
     const cache = await axios.storage.get(id, config);
 
     // Update other entries before updating himself

--- a/src/interceptors/response.ts
+++ b/src/interceptors/response.ts
@@ -62,7 +62,7 @@ export function defaultResponseInterceptor(
 
       return { ...response, cached: false };
     }
-    
+
     if (!isMethodIn(config.method, cacheConfig.methods)) {
       if (__ACI_DEV__) {
         axios.debug?.({

--- a/src/interceptors/response.ts
+++ b/src/interceptors/response.ts
@@ -64,7 +64,7 @@ export function defaultResponseInterceptor(
     }
 
     // Update other entries before updating himself
-    if (cacheConfig?.update) {
+    if (cacheConfig.update) {
       await updateCache(axios.storage, response, cacheConfig.update);
     }
 

--- a/src/interceptors/response.ts
+++ b/src/interceptors/response.ts
@@ -63,6 +63,11 @@ export function defaultResponseInterceptor(
       return { ...response, cached: false };
     }
 
+    // Update other entries before updating himself
+    if (cacheConfig?.update) {
+      await updateCache(axios.storage, response, cacheConfig.update);
+    }
+
     if (!isMethodIn(config.method, cacheConfig.methods)) {
       if (__ACI_DEV__) {
         axios.debug?.({
@@ -74,11 +79,6 @@ export function defaultResponseInterceptor(
     }
 
     const cache = await axios.storage.get(id, config);
-
-    // Update other entries before updating himself
-    if (cacheConfig?.update) {
-      await updateCache(axios.storage, response, cacheConfig.update);
-    }
 
     if (
       // If the request interceptor had a problem or it wasn't cached

--- a/src/interceptors/response.ts
+++ b/src/interceptors/response.ts
@@ -9,7 +9,7 @@ import type { CachedStorageValue } from '../storage/types';
 import { testCachePredicate } from '../util/cache-predicate';
 import { updateCache } from '../util/update-cache';
 import type { ResponseInterceptor } from './build';
-import { createCacheResponse } from './util';
+import { createCacheResponse, isMethodIn } from './util';
 
 export function defaultResponseInterceptor(
   axios: AxiosCacheInstance

--- a/test/interceptors/response.test.ts
+++ b/test/interceptors/response.test.ts
@@ -34,6 +34,8 @@ describe('test response interceptor', () => {
     // only cache post methods
     axios.defaults.cache.methods = ['post'];
 
+    expect.assertions(1);
+
     const spy = jest.spyOn(axios.storage, 'get');
     try {
       await axios.get('http://unknown.url.lan:1234');
@@ -47,6 +49,8 @@ describe('test response interceptor', () => {
     const axios = setupCache(instance, {});
     // only cache get methods
     axios.defaults.cache.methods = ['get'];
+
+    expect.assertions(1);
 
     const spy = jest.spyOn(axios.storage, 'get');
     try {

--- a/test/interceptors/response.test.ts
+++ b/test/interceptors/response.test.ts
@@ -1,7 +1,61 @@
+import Axios from 'axios';
+import { setupCache } from '../../src/cache/create';
 import { Header } from '../../src/header/headers';
 import { mockAxios, XMockRandom } from '../mocks/axios';
 
-describe('test request interceptor', () => {
+describe('test response interceptor', () => {
+  it('tests for storage.get call against specified methods', async () => {
+    const axios = mockAxios({
+      // only cache post methods
+      methods: ['post']
+    });
+
+    const spy = jest.spyOn(axios.storage, 'get');
+    await axios.get('http://test.com');
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('tests for storage.get call with specified methods', async () => {
+    const axios = mockAxios({
+      // only cache get methods
+      methods: ['get']
+    });
+
+    const spy = jest.spyOn(axios.storage, 'get');
+    await axios.get('http://test.com');
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('tests on error for storage.get call against specified methods', async () => {
+    const instance = Axios.create({});
+    const axios = setupCache(instance, {});
+    // only cache post methods
+    axios.defaults.cache.methods = ['post'];
+
+    const spy = jest.spyOn(axios.storage, 'get');
+    try {
+      await axios.get('http://unknown.url.lan:1234');
+    } catch (error) {
+      expect(spy).not.toHaveBeenCalled();
+    }
+  });
+
+  it('tests on error for storage.get call with specified methods', async () => {
+    const instance = Axios.create({});
+    const axios = setupCache(instance, {});
+    // only cache get methods
+    axios.defaults.cache.methods = ['get'];
+
+    const spy = jest.spyOn(axios.storage, 'get');
+    try {
+      await axios.get('http://unknown.url.lan:1234');
+    } catch (error) {
+      expect(spy).toHaveBeenCalled();
+    }
+  });
+
   it('tests cache predicate integration', async () => {
     const axios = mockAxios();
 


### PR DESCRIPTION
It seems plugin performs a `storage.get` call when getting response from requests that do not meet the method criteria (e.g. method POST).
By following the same principle in request interceptor, we make sure response does not make unnecessary calls.