### PR TITLE
fix: canStale should return false if Cache-Control: must-revalidate is present

### DIFF
--- a/src/header/interpreter.ts
+++ b/src/header/interpreter.ts
@@ -8,9 +8,7 @@ export const defaultHeaderInterpreter: HeaderInterpreter = (headers) => {
   const cacheControl: unknown = headers[Header.CacheControl];
 
   if (cacheControl) {
-    const { noCache, noStore, mustRevalidate, maxAge, immutable } = parse(
-      String(cacheControl)
-    );
+    const { noCache, noStore, maxAge, immutable } = parse(String(cacheControl));
 
     // Header told that this response should not be cached.
     if (noCache || noStore) {
@@ -21,11 +19,6 @@ export const defaultHeaderInterpreter: HeaderInterpreter = (headers) => {
       // 1 year is sufficient, as Infinity may cause problems with certain storages.
       // It might not be the best way, but a year is better than none.
       return 1000 * 60 * 60 * 24 * 365;
-    }
-
-    // Already out of date, for cache can be saved, but must be requested again
-    if (mustRevalidate) {
-      return 0;
     }
 
     if (maxAge !== undefined) {

--- a/src/storage/build.ts
+++ b/src/storage/build.ts
@@ -1,3 +1,4 @@
+import { parse } from 'cache-parser';
 import type { CacheRequestConfig } from '../cache/axios';
 import { Header } from '../header/headers';
 import type { MaybePromise } from '../util/types';
@@ -15,13 +16,15 @@ export const isStorage = (obj: unknown): obj is AxiosStorage =>
 /** Returns true if this has sufficient properties to stale instead of expire. */
 export function canStale(value: CachedStorageValue): boolean {
   const headers = value.data.headers;
+  const { mustRevalidate } = parse(String(headers[Header.CacheControl]));
 
   return (
-    Header.ETag in headers ||
-    Header.LastModified in headers ||
-    Header.XAxiosCacheEtag in headers ||
-    Header.XAxiosCacheStaleIfError in headers ||
-    Header.XAxiosCacheLastModified in headers
+    (Header.ETag in headers ||
+      Header.LastModified in headers ||
+      Header.XAxiosCacheEtag in headers ||
+      Header.XAxiosCacheStaleIfError in headers ||
+      Header.XAxiosCacheLastModified in headers) &&
+    !mustRevalidate
   );
 }
 

--- a/test/header/cache-control.test.ts
+++ b/test/header/cache-control.test.ts
@@ -14,12 +14,6 @@ describe('test Cache-Control header', () => {
     });
 
     expect(noCache).toBe('dont cache');
-
-    const mustRevalidate = defaultHeaderInterpreter({
-      [Header.CacheControl]: 'must-revalidate'
-    });
-
-    expect(mustRevalidate).toBe(0);
   });
 
   it('tests with maxAge header for 10 seconds', () => {
@@ -29,6 +23,12 @@ describe('test Cache-Control header', () => {
 
     // 10 Seconds in milliseconds
     expect(result).toBe(10 * 1000);
+
+    const mustRevalidate = defaultHeaderInterpreter({
+      [Header.CacheControl]: 'max-age=10, must-revalidate'
+    });
+
+    expect(mustRevalidate).toBe(10000);
   });
 
   it('tests with max-age of 0', () => {

--- a/test/interceptors/request.test.ts
+++ b/test/interceptors/request.test.ts
@@ -113,12 +113,12 @@ describe('test request interceptor', () => {
   });
 
   it('tests "must revalidate" handling without any headers to do so', async () => {
-    const axios = mockAxios({}, { 'cache-control': 'must-revalidate' });
+    const axios = mockAxios({}, { 'cache-control': 'max-age=1, must-revalidate' });
     const config = { cache: { interpretHeader: true } };
     await axios.get('http://test.com', config);
 
-    // 0ms cache
-    await sleep(1);
+    // 1s cache
+    await sleep(1000);
 
     const response = await axios.get('http://test.com', config);
     // nothing to use for revalidation


### PR DESCRIPTION
### Description
This PR contains the following changes:
 -  Fix for incorrect behavior of canStale function.
 - Updated test cases. [1 failing test case is pending]

### Relevant Issue:
 #507