### PR TITLE
fix: Support stale-while-revalidate

### DIFF
--- a/src/header/interpreter.ts
+++ b/src/header/interpreter.ts
@@ -8,9 +8,9 @@ export const defaultHeaderInterpreter: HeaderInterpreter = (headers) => {
   const cacheControl: unknown = headers[Header.CacheControl];
 
   if (cacheControl) {
-    const { noCache, noStore, mustRevalidate, maxAge, immutable } = parse(
-      String(cacheControl)
-    );
+    const { noCache, noStore, mustRevalidate, maxAge, immutable, staleWhileRevalidate } =
+      parse(String(cacheControl));
+    const staleTtl = staleWhileRevalidate !== undefined ? staleWhileRevalidate * 1000 : 0;
 
     // Header told that this response should not be cached.
     if (noCache || noStore) {
@@ -20,22 +20,22 @@ export const defaultHeaderInterpreter: HeaderInterpreter = (headers) => {
     if (immutable) {
       // 1 year is sufficient, as Infinity may cause problems with certain storages.
       // It might not be the best way, but a year is better than none.
-      return 1000 * 60 * 60 * 24 * 365;
+      return { cacheTtl: 1000 * 60 * 60 * 24 * 365 };
     }
 
     // Already out of date, for cache can be saved, but must be requested again
     if (mustRevalidate) {
-      return 0;
+      return { cacheTtl: 0, staleTtl };
     }
 
     if (maxAge !== undefined) {
       const age: unknown = headers[Header.Age];
 
       if (!age) {
-        return maxAge * 1000;
+        return { cacheTtl: maxAge * 1000, staleTtl };
       }
 
-      return (maxAge - Number(age)) * 1000;
+      return { cacheTtl: (maxAge - Number(age)) * 1000, staleTtl };
     }
   }
 
@@ -43,7 +43,7 @@ export const defaultHeaderInterpreter: HeaderInterpreter = (headers) => {
 
   if (expires) {
     const milliseconds = Date.parse(String(expires)) - Date.now();
-    return milliseconds >= 0 ? milliseconds : 'dont cache';
+    return milliseconds >= 0 ? { cacheTtl: milliseconds } : 'dont cache';
   }
 
   return 'not enough headers';

--- a/src/header/types.ts
+++ b/src/header/types.ts
@@ -1,6 +1,11 @@
 import type { CacheAxiosResponse } from '../cache/axios';
 
-export type InterpreterResult = 'dont cache' | 'not enough headers' | number;
+export type TtlData = {
+  cacheTtl: number;
+  staleTtl?: number;
+};
+
+export type InterpreterResult = 'dont cache' | 'not enough headers' | TtlData;
 
 /**
  * - If activated, when the response is received, the `ttl` property will be inferred from

--- a/src/header/types.ts
+++ b/src/header/types.ts
@@ -1,20 +1,20 @@
 import type { CacheAxiosResponse } from '../cache/axios';
 
-export type TtlData = {
-  cacheTtl: number;
-  staleTtl?: number;
-};
-
 /**
- * @deprecated
+ * The possible values are:
+ * - `'dont cache'`: the request will not be cached.
+ * - `'not enough headers'`: the request will find other ways to determine the TTL value.
+ * - `number`: used as the TTL value.
+ * - `{ cache: number, stale: number }: used as the TTL value and stale TTL value`
  */
-export type DeprecatedTtlData = number;
-
 export type InterpreterResult =
   | 'dont cache'
   | 'not enough headers'
-  | DeprecatedTtlData
-  | TtlData;
+  | number
+  | {
+      cache: number;
+      stale?: number;
+    };
 
 /**
  * - If activated, when the response is received, the `ttl` property will be inferred from
@@ -25,6 +25,7 @@ export type InterpreterResult =
  * - `'dont cache'`: the request will not be cached.
  * - `'not enough headers'`: the request will find other ways to determine the TTL value.
  * - `number`: used as the TTL value.
+ * - `{ cache: number, stale: number }: used as the TTL value and stale TTL value`
  *
  * @param header The header object to interpret.
  * @returns `false` if cache should not be used. `undefined` when provided headers was not

--- a/src/header/types.ts
+++ b/src/header/types.ts
@@ -5,7 +5,16 @@ export type TtlData = {
   staleTtl?: number;
 };
 
-export type InterpreterResult = 'dont cache' | 'not enough headers' | TtlData;
+/**
+ * @deprecated
+ */
+export type DeprecatedTtlData = number;
+
+export type InterpreterResult =
+  | 'dont cache'
+  | 'not enough headers'
+  | DeprecatedTtlData
+  | TtlData;
 
 /**
  * - If activated, when the response is received, the `ttl` property will be inferred from

--- a/src/interceptors/response.ts
+++ b/src/interceptors/response.ts
@@ -136,6 +136,7 @@ export function defaultResponseInterceptor(
     }
 
     let ttl = cacheConfig.ttl || -1; // always set from global config
+    let staleTtl;
 
     if (cacheConfig.interpretHeader) {
       const expirationTime = axios.headerInterpreter(response.headers);
@@ -155,7 +156,10 @@ export function defaultResponseInterceptor(
         return response;
       }
 
-      ttl = expirationTime === 'not enough headers' ? ttl : expirationTime;
+      if (expirationTime !== 'not enough headers') {
+        ttl = expirationTime.cacheTtl;
+        staleTtl = expirationTime.staleTtl;
+      }
     }
 
     const data = createCacheResponse(response, cache.data);
@@ -179,6 +183,7 @@ export function defaultResponseInterceptor(
     const newCache: CachedStorageValue = {
       state: 'cached',
       ttl,
+      staleTtl,
       createdAt: Date.now(),
       data
     };

--- a/src/interceptors/response.ts
+++ b/src/interceptors/response.ts
@@ -157,8 +157,13 @@ export function defaultResponseInterceptor(
       }
 
       if (expirationTime !== 'not enough headers') {
-        ttl = expirationTime.cacheTtl;
-        staleTtl = expirationTime.staleTtl;
+        // backward compatibility
+        if (typeof expirationTime === 'number') {
+          ttl = expirationTime;
+        } else {
+          ttl = expirationTime.cacheTtl;
+          staleTtl = expirationTime.staleTtl;
+        }
       }
     }
 

--- a/src/interceptors/response.ts
+++ b/src/interceptors/response.ts
@@ -136,7 +136,7 @@ export function defaultResponseInterceptor(
     }
 
     let ttl = cacheConfig.ttl || -1; // always set from global config
-    let staleTtl;
+    let staleTtl: number | undefined;
 
     if (cacheConfig.interpretHeader) {
       const expirationTime = axios.headerInterpreter(response.headers);
@@ -157,12 +157,11 @@ export function defaultResponseInterceptor(
       }
 
       if (expirationTime !== 'not enough headers') {
-        // backward compatibility
         if (typeof expirationTime === 'number') {
           ttl = expirationTime;
         } else {
-          ttl = expirationTime.cacheTtl;
-          staleTtl = expirationTime.staleTtl;
+          ttl = expirationTime.cache;
+          staleTtl = expirationTime.stale;
         }
       }
     }

--- a/src/storage/build.ts
+++ b/src/storage/build.ts
@@ -116,6 +116,7 @@ export function buildStorage({ set, find, remove }: BuildStorage): AxiosStorage 
         await set(key, value, config);
       }
 
+      // A second check in case the new stale value was created already expired.
       if (!isExpired(value)) {
         return value;
       }

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -19,7 +19,7 @@ export type NotEmptyStorageValue = Exclude<StorageValue, EmptyStorageValue>;
 
 export type StaleStorageValue = {
   data: CachedResponse;
-  ttl?: undefined;
+  ttl?: number;
   createdAt: number;
   state: 'stale';
 };
@@ -31,6 +31,7 @@ export type CachedStorageValue = {
    * stale.
    */
   ttl: number;
+  staleTtl?: number;
   createdAt: number;
   state: 'cached';
 };

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -20,6 +20,7 @@ export type NotEmptyStorageValue = Exclude<StorageValue, EmptyStorageValue>;
 export type StaleStorageValue = {
   data: CachedResponse;
   ttl?: number;
+  staleTtl?: undefined;
   createdAt: number;
   state: 'stale';
 };
@@ -41,6 +42,7 @@ export type LoadingStorageValue = LoadingEmptiedStorageValue | LoadingStaledStor
 export type LoadingEmptiedStorageValue = {
   data?: undefined;
   ttl?: undefined;
+  staleTtl?: undefined;
   createdAt?: undefined;
   state: 'loading';
   previous: 'empty';
@@ -50,6 +52,7 @@ export type LoadingStaledStorageValue = {
   state: 'loading';
   data: CachedResponse;
   ttl?: undefined;
+  staleTtl?: undefined;
   createdAt: number;
   previous: 'stale';
 };
@@ -57,6 +60,7 @@ export type LoadingStaledStorageValue = {
 export type EmptyStorageValue = {
   data?: undefined;
   ttl?: undefined;
+  staleTtl?: undefined;
 
   /** Defined when the state is cached */
   createdAt?: undefined;

--- a/test/header/cache-control.test.ts
+++ b/test/header/cache-control.test.ts
@@ -19,7 +19,7 @@ describe('test Cache-Control header', () => {
       [Header.CacheControl]: 'must-revalidate'
     });
 
-    expect(mustRevalidate).toEqual({ cacheTtl: 0, staleTtl: 0 });
+    expect(mustRevalidate).toEqual({ cache: 0, stale: 0 });
   });
 
   it('tests with maxAge header for 10 seconds', () => {
@@ -28,7 +28,7 @@ describe('test Cache-Control header', () => {
     });
 
     // 10 Seconds in milliseconds
-    expect(result).toEqual({ cacheTtl: 10 * 1000, staleTtl: 0 });
+    expect(result).toEqual({ cache: 10 * 1000, stale: 0 });
   });
 
   it('tests with max-age of 0', () => {
@@ -36,6 +36,6 @@ describe('test Cache-Control header', () => {
       [Header.CacheControl]: 'max-age=0'
     });
 
-    expect(result).toEqual({ cacheTtl: 0, staleTtl: 0 });
+    expect(result).toEqual({ cache: 0, stale: 0 });
   });
 });

--- a/test/header/cache-control.test.ts
+++ b/test/header/cache-control.test.ts
@@ -19,7 +19,7 @@ describe('test Cache-Control header', () => {
       [Header.CacheControl]: 'must-revalidate'
     });
 
-    expect(mustRevalidate).toBe(0);
+    expect(mustRevalidate).toEqual({ cacheTtl: 0, staleTtl: 0 });
   });
 
   it('tests with maxAge header for 10 seconds', () => {
@@ -28,7 +28,7 @@ describe('test Cache-Control header', () => {
     });
 
     // 10 Seconds in milliseconds
-    expect(result).toBe(10 * 1000);
+    expect(result).toEqual({ cacheTtl: 10 * 1000, staleTtl: 0 });
   });
 
   it('tests with max-age of 0', () => {
@@ -36,7 +36,6 @@ describe('test Cache-Control header', () => {
       [Header.CacheControl]: 'max-age=0'
     });
 
-    expect(result).toBe(0);
-    expect(result).not.toBe('not enough headers');
+    expect(result).toEqual({ cacheTtl: 0, staleTtl: 0 });
   });
 });

--- a/test/header/expires.test.ts
+++ b/test/header/expires.test.ts
@@ -15,9 +15,11 @@ describe('test Expires header', () => {
       return expect(true).toBeFalsy();
     }
 
+    const cacheTtl = typeof result === 'number' ? result : result.cacheTtl;
+
     // the result should be what the date is in milliseconds
     // minus the actual epoch milliseconds
-    expect(Math.abs(result.cacheTtl - approx)).toBeLessThanOrEqual(1);
+    expect(Math.abs(cacheTtl - approx)).toBeLessThanOrEqual(1);
   });
 
   it('expects Expires to be used when invalid Cache-Control is provided', () => {

--- a/test/header/expires.test.ts
+++ b/test/header/expires.test.ts
@@ -11,15 +11,13 @@ describe('test Expires header', () => {
 
     const approx = date.getTime() - Date.now();
 
-    expect(typeof result).toBe('number');
-
-    if (typeof result !== 'number') {
+    if (typeof result === 'string') {
       return expect(true).toBeFalsy();
     }
 
     // the result should be what the date is in milliseconds
     // minus the actual epoch milliseconds
-    expect(Math.abs(result - approx)).toBeLessThanOrEqual(1);
+    expect(Math.abs(result.cacheTtl - approx)).toBeLessThanOrEqual(1);
   });
 
   it('expects Expires to be used when invalid Cache-Control is provided', () => {

--- a/test/header/expires.test.ts
+++ b/test/header/expires.test.ts
@@ -15,11 +15,11 @@ describe('test Expires header', () => {
       return expect(true).toBeFalsy();
     }
 
-    const cacheTtl = typeof result === 'number' ? result : result.cacheTtl;
+    const cache = typeof result === 'number' ? result : result.cache;
 
     // the result should be what the date is in milliseconds
     // minus the actual epoch milliseconds
-    expect(Math.abs(cacheTtl - approx)).toBeLessThanOrEqual(1);
+    expect(Math.abs(cache - approx)).toBeLessThanOrEqual(1);
   });
 
   it('expects Expires to be used when invalid Cache-Control is provided', () => {

--- a/test/header/interpreter.test.ts
+++ b/test/header/interpreter.test.ts
@@ -22,7 +22,7 @@ describe('tests header interpreter', () => {
       [Header.Age]: '3'
     });
 
-    expect(result).toBe(7 * 1000);
+    expect(result).toEqual({ cacheTtl: 7 * 1000, staleTtl: 0 });
   });
 
   it('tests with expires and cache-control present', () => {
@@ -33,7 +33,7 @@ describe('tests header interpreter', () => {
 
     // expires should be ignored
     // 10 Seconds in milliseconds
-    expect(result).toBe(10 * 1000);
+    expect(result).toEqual({ cacheTtl: 10 * 1000, staleTtl: 0 });
   });
 
   it('tests with immutable', () => {
@@ -42,6 +42,26 @@ describe('tests header interpreter', () => {
     });
 
     // 1 year
-    expect(result).toBe(1000 * 60 * 60 * 24 * 365);
+    expect(result).toEqual({ cacheTtl: 1000 * 60 * 60 * 24 * 365 });
+  });
+
+  it('tests with maxAge=10 and age=3 and staleWhileRevalidate headers', () => {
+    const result = defaultHeaderInterpreter({
+      [Header.CacheControl]: 'max-age=10,stale-while-revalidate=5',
+      [Header.Age]: '3'
+    });
+
+    expect(result).toEqual({ cacheTtl: 7 * 1000, staleTtl: 5 * 1000 });
+  });
+
+  it('tests with expires and cache-control and staleWhileRevalidate present', () => {
+    const result = defaultHeaderInterpreter({
+      [Header.CacheControl]: 'max-age=10,stale-while-revalidate=5',
+      [Header.Expires]: new Date(new Date().getFullYear() + 1, 1, 1).toUTCString()
+    });
+
+    // expires should be ignored
+    // 10 Seconds in milliseconds
+    expect(result).toEqual({ cacheTtl: 10 * 1000, staleTtl: 5 * 1000 });
   });
 });

--- a/test/interceptors/hydrate.test.ts
+++ b/test/interceptors/hydrate.test.ts
@@ -18,7 +18,7 @@ describe('Hydrate works', () => {
   it('only hydrates when cache is stale', async () => {
     const axios = mockAxios(
       {},
-      { [Header.CacheControl]: 'max-age=100,stale-while-revalidate=100' }
+      { [Header.CacheControl]: 'max-age=100, stale-while-revalidate=100' }
     );
     const id = 'some-unique-id';
 
@@ -43,7 +43,7 @@ describe('Hydrate works', () => {
   it('hydrates when cache is stale', async () => {
     const axios = mockAxios(
       {},
-      { [Header.CacheControl]: 'max-age=0,stale-while-revalidate=100' }
+      { [Header.CacheControl]: 'max-age=0, stale-while-revalidate=100' }
     );
     const id = 'some-unique-id';
 
@@ -100,7 +100,7 @@ describe('Hydrate works', () => {
   it('only hydrates when stale while revalidate is set', async () => {
     const axios = mockAxios(
       {},
-      { [Header.CacheControl]: 'max-age=0,stale-while-revalidate=0' }
+      { [Header.CacheControl]: 'max-age=0, stale-while-revalidate=0' }
     );
     const id = 'some-unique-id';
 
@@ -125,7 +125,7 @@ describe('Hydrate works', () => {
   it('only hydrates when stale while revalidate is not expired', async () => {
     const axios = mockAxios(
       {},
-      { [Header.CacheControl]: 'max-age=0,stale-while-revalidate=1' }
+      { [Header.CacheControl]: 'max-age=0, stale-while-revalidate=1' }
     );
     const id = 'some-unique-id';
 

--- a/test/interceptors/hydrate.test.ts
+++ b/test/interceptors/hydrate.test.ts
@@ -1,4 +1,6 @@
+import { Header } from '../../src';
 import { mockAxios } from '../mocks/axios';
+import { sleep } from '../utils';
 
 describe('Hydrate works', () => {
   it('expects that hydrate is only called when a cache exists', async () => {
@@ -13,8 +15,11 @@ describe('Hydrate works', () => {
     expect(mock).not.toHaveBeenCalled();
   });
 
-  it('only hydrates when cache is returned', async () => {
-    const axios = mockAxios({});
+  it('only hydrates when cache is stale', async () => {
+    const axios = mockAxios(
+      {},
+      { [Header.CacheControl]: 'max-age=100,stale-while-revalidate=100' }
+    );
     const id = 'some-unique-id';
 
     const mock = jest.fn();
@@ -35,8 +40,68 @@ describe('Hydrate works', () => {
     expect(res2.cached).toBe(true);
   });
 
-  it('hydrates when a new request is needed', async () => {
-    const axios = mockAxios({});
+  it('hydrates when cache is stale', async () => {
+    const axios = mockAxios(
+      {},
+      { [Header.CacheControl]: 'max-age=0,stale-while-revalidate=100' }
+    );
+    const id = 'some-unique-id';
+
+    const mock = jest.fn();
+
+    await axios.get('url', {
+      id,
+      cache: { hydrate: mock }
+    });
+
+    expect(mock).not.toHaveBeenCalled();
+
+    const cache = await axios.storage.get(id);
+    const res2 = await axios.get('url', {
+      id,
+      cache: { hydrate: mock }
+    });
+
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(res2.cached).toBe(false);
+    expect(mock).toHaveBeenCalledWith(cache);
+  });
+
+  it('hydrates when etag is set', async () => {
+    const axios = mockAxios(
+      {},
+      {
+        [Header.ETag]: '42',
+        [Header.CacheControl]: 'max-age=0'
+      }
+    );
+    const id = 'some-unique-id';
+
+    const mock = jest.fn();
+
+    await axios.get('url', {
+      id,
+      cache: { hydrate: mock }
+    });
+
+    expect(mock).not.toHaveBeenCalled();
+
+    const cache = await axios.storage.get(id);
+    const res2 = await axios.get('url', {
+      id,
+      cache: { hydrate: mock }
+    });
+
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(res2.cached).toBe(true);
+    expect(mock).toHaveBeenCalledWith(cache);
+  });
+
+  it('only hydrates when stale while revalidate is set', async () => {
+    const axios = mockAxios(
+      {},
+      { [Header.CacheControl]: 'max-age=0,stale-while-revalidate=0' }
+    );
     const id = 'some-unique-id';
 
     const mock = jest.fn();
@@ -54,10 +119,52 @@ describe('Hydrate works', () => {
     });
 
     expect(mock).not.toHaveBeenCalled();
-    expect(res2.cached).toBe(true);
+    expect(res2.cached).toBe(false);
+  });
+
+  it('only hydrates when stale while revalidate is not expired', async () => {
+    const axios = mockAxios(
+      {},
+      { [Header.CacheControl]: 'max-age=0,stale-while-revalidate=1' }
+    );
+    const id = 'some-unique-id';
+
+    const mock = jest.fn();
+
+    await axios.get('url', {
+      id,
+      cache: { hydrate: mock }
+    });
+
+    expect(mock).not.toHaveBeenCalled();
+
+    // Sleep entire max age time.
+    await sleep(1000);
+
+    const res2 = await axios.get('url', {
+      id,
+      cache: { hydrate: mock }
+    });
+
+    expect(mock).not.toHaveBeenCalled();
+    expect(res2.cached).toBe(false);
+  });
+
+  it('hydrates when force stale', async () => {
+    const axios = mockAxios({}, { [Header.CacheControl]: `max-age=100` });
+    const id = 'some-unique-id';
+
+    const mock = jest.fn();
+
+    await axios.get('url', {
+      id,
+      cache: { hydrate: mock }
+    });
+
+    expect(mock).not.toHaveBeenCalled();
 
     const cache = await axios.storage.get(id);
-    const res3 = await axios.get('url', {
+    const res2 = await axios.get('url', {
       id,
       cache: {
         hydrate: mock,
@@ -66,7 +173,7 @@ describe('Hydrate works', () => {
     });
 
     expect(mock).toHaveBeenCalledTimes(1);
-    expect(res3.cached).toBe(false);
+    expect(res2.cached).toBe(false);
     expect(mock).toHaveBeenCalledWith(cache);
   });
 });

--- a/test/interceptors/request.test.ts
+++ b/test/interceptors/request.test.ts
@@ -98,7 +98,10 @@ describe('test request interceptor', () => {
   });
 
   it('test cache expiration', async () => {
-    const axios = mockAxios({}, { 'cache-control': 'max-age=1' });
+    const axios = mockAxios(
+      {},
+      { 'cache-control': 'max-age=1,stale-while-revalidate=10' }
+    );
 
     await axios.get('http://test.com', { cache: { interpretHeader: true } });
 

--- a/test/interceptors/response.test.ts
+++ b/test/interceptors/response.test.ts
@@ -100,16 +100,6 @@ describe('test response interceptor', () => {
     expect(resultCache.cached).toBe(true);
   });
 
-  it('tests header interpreter integration deprecated', async () => {
-    const axios = mockAxios({ headerInterpreter: () => 100 }, {});
-
-    // Make first request to cache it
-    await axios.get('http://test.com', { cache: { interpretHeader: true } });
-    const result = await axios.get('http://test.com');
-
-    expect(result.cached).toBe(true);
-  });
-
   it('tests update cache integration', async () => {
     const axios = mockAxios();
 

--- a/test/interceptors/response.test.ts
+++ b/test/interceptors/response.test.ts
@@ -100,6 +100,16 @@ describe('test response interceptor', () => {
     expect(resultCache.cached).toBe(true);
   });
 
+  it('tests header interpreter integration deprecated', async () => {
+    const axios = mockAxios({ headerInterpreter: () => 100 }, {});
+
+    // Make first request to cache it
+    await axios.get('http://test.com', { cache: { interpretHeader: true } });
+    const result = await axios.get('http://test.com');
+
+    expect(result.cached).toBe(true);
+  });
+
   it('tests update cache integration', async () => {
     const axios = mockAxios();
 


### PR DESCRIPTION
This PR fixes #512 
Note: this probably generate conflicts with #510

Also, I'm not completely convinced about the `hydrate` implementation. Currently, when we have a stale value we do the following:
- call the hydrate function with the stale data
- refetch the data and return result with cached === false

To me, this should be the opposite, thus:
- return the stale data with cached === true (when stale-while-revalidate allows us to do that)
- refetch the data, and call the hydrate function with the fresh data (if set)

This would allow for RFC compliance while also allowing users to get the fresh data as soon as it is available should they need it (when used on a server it does not necessarily make sense to use the double return technique).  
However, should we want to make the change above, I think the current PR can still be merged and the change above be made in another PR.