### PR TITLE
Turn most types into interfaces

### DIFF
--- a/docs/src/guide/interceptors.md
+++ b/docs/src/guide/interceptors.md
@@ -41,13 +41,20 @@ axios.interceptors.response.use((res) => res);
 
 ## Extending types
 
-As this package overrides the `AxiosInstance` interface with its own types,
-in case of adding other interceptors or custom code, you need to create
-a proper namespace for them:
+When using axios-cache-interceptor, you'll note that it have a different type
+than the defaults `AxiosInstance`, `AxiosRequestConfig` and `AxiosResponse`.
+That's because was chosen to override axios's interfaces instead of extending,
+to avoid breaking changes with other libraries.
+
+However, this also means that when integrating with other packages or creating
+your own custom interceptor, you need to override/extend our own types,
+`CacheInstance`, `CacheRequestConfig` and `CacheAxiosResponse` to match your needs.
+
+This can be done as shown below:
 
 ```ts
 declare module 'axios-cache-interceptor' {
-  interface CacheRequestConfig<R = any, D = any> {
+  interface CacheRequestConfig<R = unknown, D = unknown> {
     customProperty: string;
   }
 }

--- a/docs/src/guide/interceptors.md
+++ b/docs/src/guide/interceptors.md
@@ -36,3 +36,20 @@ axios.interceptors.request.use((req) => req);
 // This will be ran BEFORE the cache interceptor
 axios.interceptors.response.use((res) => res);
 ```
+
+---
+
+## Extending types
+
+As this package overrides the `AxiosInstance` interface with its own types,
+in case of adding other interceptors or custom code, you need to create
+a proper namespace for them:
+
+```ts
+declare module 'axios-cache-interceptor' {
+  interface CacheRequestConfig<R = any, D = any> {
+    customProperty: string;
+  }
+}
+```
+

--- a/src/cache/axios.ts
+++ b/src/cache/axios.ts
@@ -54,7 +54,7 @@ export type CacheAxiosResponse<R = any, D = any> = AxiosResponse<R, D> & {
  * @template R The type returned by this response
  * @template D The type for the request body
  */
-export type CacheRequestConfig<R = any, D = any> = AxiosRequestConfig<D> & {
+export interface CacheRequestConfig<R = any, D = any> extends AxiosRequestConfig<D> {
   /**
    * The [Request ID](https://axios-cache-interceptor.js.org/guide/request-id) used in
    * this request.
@@ -81,12 +81,13 @@ export type CacheRequestConfig<R = any, D = any> = AxiosRequestConfig<D> & {
    * @see https://axios-cache-interceptor.js.org/config/response-object#cache
    */
   cache?: false | Partial<CacheProperties<R, D>>;
-};
+}
 
 /** Cached version of type {@link InternalAxiosRequestConfig} */
-export type InternalCacheRequestConfig<R = any, D = any> = CacheRequestConfig<R, D> & {
+export interface InternalCacheRequestConfig<R = any, D = any>
+  extends CacheRequestConfig<R, D> {
   headers: AxiosResponseHeaders;
-};
+}
 
 /**
  * Same as the AxiosInstance but with CacheRequestConfig as a config type and

--- a/src/cache/axios.ts
+++ b/src/cache/axios.ts
@@ -18,8 +18,8 @@ import type { CacheInstance, CacheProperties } from './cache';
  * @template D The type that the request body was
  * @see https://axios-cache-interceptor.js.org/config/response-object
  */
-export type CacheAxiosResponse<R = any, D = any> = AxiosResponse<R, D> & {
-  config: CacheRequestConfig<R, D>;
+export interface CacheAxiosResponse<R = any, D = any> extends AxiosResponse<R, D> {
+  config: InternalCacheRequestConfig<R, D>;
 
   /**
    * The [Request ID](https://axios-cache-interceptor.js.org/guide/request-id) used in
@@ -46,7 +46,7 @@ export type CacheAxiosResponse<R = any, D = any> = AxiosResponse<R, D> & {
    * @see https://axios-cache-interceptor.js.org/config/response-object#cached
    */
   cached: boolean;
-};
+}
 
 /**
  * Options that can be overridden per request

--- a/src/cache/cache.ts
+++ b/src/cache/cache.ts
@@ -21,7 +21,7 @@ import type { CacheAxiosResponse, CacheRequestConfig } from './axios';
  * @template R The type returned by this response
  * @template D The type for the request body
  */
-export type CacheProperties<R = unknown, D = unknown> = {
+export interface CacheProperties<R = unknown, D = unknown> {
   /**
    * The time until the cached value is expired in milliseconds.
    *
@@ -211,7 +211,7 @@ export type CacheProperties<R = unknown, D = unknown> = {
           | CachedStorageValue
           | StaleStorageValue
       ) => void | Promise<void>);
-};
+}
 
 /**
  * These are properties that are used and shared by the entire application.
@@ -342,4 +342,8 @@ export interface CacheInstance {
  *
  * @see https://axios-cache-interceptor.js.org/#/pages/development-mode
  */
-export type DebugObject = { id?: string; msg?: string; data?: unknown };
+export interface DebugObject {
+  id?: string;
+  msg?: string;
+  data?: unknown;
+}

--- a/src/cache/create.ts
+++ b/src/cache/create.ts
@@ -8,7 +8,7 @@ import { defaultKeyGenerator } from '../util/key-generator';
 import type { AxiosCacheInstance } from './axios';
 import type { CacheInstance, CacheProperties } from './cache';
 
-export type CacheOptions = Partial<CacheInstance> & Partial<CacheProperties>;
+export interface CacheOptions extends Partial<CacheInstance>, Partial<CacheProperties> {}
 
 /**
  * Apply the caching interceptors for a already created axios instance.

--- a/src/interceptors/util.ts
+++ b/src/interceptors/util.ts
@@ -25,9 +25,9 @@ export function isMethodIn(
   return methodList.some((method) => method === requestMethod);
 }
 
-export type ConfigWithCache<D> = CacheRequestConfig<unknown, D> & {
-  cache: Partial<CacheProperties>;
-};
+export interface ConfigWithCache<D> extends CacheRequestConfig<unknown, D> {
+  cache: Partial<CacheProperties<unknown, D>>;
+}
 
 /**
  * This function updates the cache when the request is stale. So, the next request to the

--- a/src/storage/build.ts
+++ b/src/storage/build.ts
@@ -61,7 +61,7 @@ export function isExpired(value: CachedStorageValue | StaleStorageValue): boolea
   return value.ttl !== undefined && value.createdAt + value.ttl <= Date.now();
 }
 
-export type BuildStorage = Omit<AxiosStorage, 'get'> & {
+export interface BuildStorage extends Omit<AxiosStorage, 'get'> {
   /**
    * Returns the value for the given key. This method does not have to make checks for
    * cache invalidation or anything. It just returns what was previous saved, if present.
@@ -74,7 +74,7 @@ export type BuildStorage = Omit<AxiosStorage, 'get'> & {
     key: string,
     currentRequest?: CacheRequestConfig
   ) => MaybePromise<StorageValue | undefined>;
-};
+}
 
 /**
  * All integrated storages are wrappers around the `buildStorage` function. External

--- a/src/storage/memory.ts
+++ b/src/storage/memory.ts
@@ -141,10 +141,10 @@ export function buildMemoryStorage(
   return storage;
 }
 
-export type MemoryStorage = AxiosStorage & {
+export interface MemoryStorage extends AxiosStorage {
   data: Record<string, StorageValue>;
   /** The job responsible to cleaning old entries */
   cleaner: ReturnType<typeof setInterval>;
   /** Tries to remove any invalid entry from the memory */
   cleanup: () => void;
-};
+}

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -1,12 +1,12 @@
 import type { CacheAxiosResponse, CacheRequestConfig } from '../cache/axios';
 import type { MaybePromise } from '../util/types';
 
-export type CachedResponse = {
+export interface CachedResponse {
   data?: unknown;
   headers: CacheAxiosResponse['headers'];
   status: number;
   statusText: string;
-};
+}
 
 /** The value returned for a given key. */
 export type StorageValue =
@@ -17,15 +17,15 @@ export type StorageValue =
 
 export type NotEmptyStorageValue = Exclude<StorageValue, EmptyStorageValue>;
 
-export type StaleStorageValue = {
+export interface StaleStorageValue {
   data: CachedResponse;
   ttl?: number;
   staleTtl?: undefined;
   createdAt: number;
   state: 'stale';
-};
+}
 
-export type CachedStorageValue = {
+export interface CachedStorageValue {
   data: CachedResponse;
   /**
    * The number in milliseconds to wait after createdAt before the value is considered
@@ -35,29 +35,29 @@ export type CachedStorageValue = {
   staleTtl?: number;
   createdAt: number;
   state: 'cached';
-};
+}
 
 export type LoadingStorageValue = LoadingEmptiedStorageValue | LoadingStaledStorageValue;
 
-export type LoadingEmptiedStorageValue = {
+export interface LoadingEmptiedStorageValue {
   data?: undefined;
   ttl?: undefined;
   staleTtl?: undefined;
   createdAt?: undefined;
   state: 'loading';
   previous: 'empty';
-};
+}
 
-export type LoadingStaledStorageValue = {
+export interface LoadingStaledStorageValue {
   state: 'loading';
   data: CachedResponse;
   ttl?: undefined;
   staleTtl?: undefined;
   createdAt: number;
   previous: 'stale';
-};
+}
 
-export type EmptyStorageValue = {
+export interface EmptyStorageValue {
   data?: undefined;
   ttl?: undefined;
   staleTtl?: undefined;
@@ -65,7 +65,7 @@ export type EmptyStorageValue = {
   /** Defined when the state is cached */
   createdAt?: undefined;
   state: 'empty';
-};
+}
 
 /**
  * A storage interface is the entity responsible for saving, retrieving and serializing
@@ -74,7 +74,7 @@ export type EmptyStorageValue = {
  * @default buildMemoryStorage
  * @see https://axios-cache-interceptor.js.org/guide/storages
  */
-export type AxiosStorage = {
+export interface AxiosStorage {
   /**
    * Sets a new value for the given key
    *
@@ -113,4 +113,4 @@ export type AxiosStorage = {
    * @see https://axios-cache-interceptor.js.org/guide/storages#buildstorage
    */
   get: (key: string, currentRequest?: CacheRequestConfig) => MaybePromise<StorageValue>;
-};
+}

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -10,7 +10,7 @@ export type CachePredicate<R = unknown, D = unknown> = Exclude<
   undefined
 >;
 
-export type CachePredicateObject<R = unknown, D = unknown> = {
+export interface CachePredicateObject<R = unknown, D = unknown> {
   /** Matches if this function returned true. */
   statusCheck?: (status: number) => MaybePromise<boolean>;
 
@@ -29,7 +29,7 @@ export type CachePredicateObject<R = unknown, D = unknown> = {
 
   /** Check if the response matches this predicate. */
   responseMatch?: (res: CacheAxiosResponse<R, D>) => MaybePromise<boolean>;
-};
+}
 
 /**
  * A simple function that receives a cache request config and should return a string id
@@ -68,14 +68,14 @@ export type CacheUpdaterFn<R, D> = (
  * `delete` -> Deletes the request cache `predicate()` -> Determines if the cache can be
  * reused, deleted or modified.
  */
-export type CacheUpdaterRecord<R, D> = {
+export interface CacheUpdaterRecord<R, D> {
   [requestId: string]:
     | 'delete'
     | ((
         cached: Exclude<StorageValue, LoadingStorageValue>,
         response: CacheAxiosResponse<R, D>
       ) => MaybePromise<CachedStorageValue | 'delete' | 'ignore'>);
-};
+}
 
 /**
  * Updates any specified request cache by applying the response for this network call.


### PR DESCRIPTION
## Summary

This PR changes most types to be interfaces, thus leveraging the extensibility of the library.

---

Yet, there some `type`s left in the code:

I couldn't manage to turn callbacks or primitives into interfaces:
- [InterpreterResult](https://github.com/arthurfiorette/axios-cache-interceptor/blob/main/src/header/types.ts#L11)
- [HeaderInterpreter](https://github.com/arthurfiorette/axios-cache-interceptor/blob/main/src/header/types.ts#L37)
- [KeyGenerator](https://github.com/arthurfiorette/axios-cache-interceptor/blob/main/src/util/types.ts#L38)
- [StaleIfErrorPredicate](https://github.com/arthurfiorette/axios-cache-interceptor/blob/main/src/util/types.ts#L52)
- [CacheUpdateFn](https://github.com/arthurfiorette/axios-cache-interceptor/blob/main/src/util/types.ts#L61)
- [CacheUpdateRecord](https://github.com/arthurfiorette/axios-cache-interceptor/blob/main/src/util/types.ts#L85)

I haven't found a way to create an equivalent interface to these types, mostly because you can't extend an `Excludes<>`, `Partial<>` or a set of union types:
- [StorageValue](https://github.com/arthurfiorette/axios-cache-interceptor/blob/main/src/storage/types.ts#L12) *
- [NotEmptyStorageValue](https://github.com/arthurfiorette/axios-cache-interceptor/blob/main/src/storage/types.ts#L18)
- [LoadingStorageValue](https://github.com/arthurfiorette/axios-cache-interceptor/blob/main/src/storage/types.ts#L40) *
- [CachePredicate](https://github.com/arthurfiorette/axios-cache-interceptor/blob/main/src/util/types.ts#L8)

Some of them I thought to be better as a type, but please let me know if I'm wrong
- [MaybePromise](https://github.com/arthurfiorette/axios-cache-interceptor/blob/main/src/util/types.ts#L42)
- [RequestInterceptor](https://github.com/arthurfiorette/axios-cache-interceptor/blob/main/src/interceptors/build.ts#L13) **
- [ResponseInterceptor](https://github.com/arthurfiorette/axios-cache-interceptor/blob/main/src/interceptors/build.ts#L16) **

*The value in these cases are all interfaces, so I guess it's fine

 **Even if I turned these into interfaces, the ESLint claimed that I should not extend only one interface without any adition, since it will be some sort of copy of the extended interface

---

Closes #606 