### PR TITLE
fix clone memory option

### DIFF
--- a/src/storage/memory.ts
+++ b/src/storage/memory.ts
@@ -77,6 +77,8 @@ export function buildMemoryStorage(
             typeof structuredClone === 'function'
             ? structuredClone(value)
             : (JSON.parse(JSON.stringify(value)) as NotEmptyStorageValue)
+          : cloneData
+          ? (JSON.parse(JSON.stringify(value)) as NotEmptyStorageValue)
           : value;
     },
 


### PR DESCRIPTION
clone memory option only works if value is equal to 'double'. If clone option is true it just returns original value.