### PR TITLE
Adding an IndexedDB Storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "idb": "^7.1.1",
     "jsdom": "^22.1.0",
+    "fake-indexeddb": "^4.0.2",
     "prettier": "^2.8.8",
     "prettier-plugin-jsdoc": "^0.4.2",
     "prettier-plugin-organize-imports": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "eslint": "^8.42.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^4.2.1",
+    "idb": "^7.1.1",
     "jsdom": "^22.1.0",
     "prettier": "^2.8.8",
     "prettier-plugin-jsdoc": "^0.4.2",
@@ -84,7 +85,8 @@
     "webpack-cli": "^5.1.4"
   },
   "peerDependencies": {
-    "axios": "^1"
+    "axios": "^1",
+    "idb": "^7.1.1"
   },
   "packageManager": "pnpm@8.7.1",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ devDependencies:
   eslint-plugin-prettier:
     specifier: ^4.2.1
     version: 4.2.1(eslint-config-prettier@9.0.0)(eslint@8.48.0)(prettier@2.8.8)
+  idb:
+    specifier: ^7.1.1
+    version: 7.1.1
   jsdom:
     specifier: ^22.1.0
     version: 22.1.0
@@ -2165,6 +2168,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
+    dev: true
+
+  /idb@7.1.1:
+    resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
     dev: true
 
   /ignore@5.2.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ devDependencies:
   eslint-plugin-prettier:
     specifier: ^4.2.1
     version: 4.2.1(eslint-config-prettier@9.0.0)(eslint@8.48.0)(prettier@2.8.8)
+  fake-indexeddb:
+    specifier: ^4.0.2
+    version: 4.0.2
   idb:
     specifier: ^7.1.1
     version: 7.1.1
@@ -1342,6 +1345,11 @@ packages:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
 
+  /base64-arraybuffer-es6@0.7.0:
+    resolution: {integrity: sha512-ESyU/U1CFZDJUdr+neHRhNozeCv72Y7Vm0m1DCbjX3KBjT6eYocvAJlSk6+8+HkVwXlT1FNxhGW6q3UKAlCvvw==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
   /big-integer@1.6.51:
     resolution: {integrity: sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==}
     engines: {node: '>=0.6'}
@@ -1631,6 +1639,12 @@ packages:
       esutils: 2.0.3
     dev: true
 
+  /domexception@1.0.1:
+    resolution: {integrity: sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==}
+    dependencies:
+      webidl-conversions: 4.0.2
+    dev: true
+
   /domexception@4.0.0:
     resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
     engines: {node: '>=12'}
@@ -1889,6 +1903,12 @@ packages:
       onetime: 6.0.0
       signal-exit: 3.0.7
       strip-final-newline: 3.0.0
+    dev: true
+
+  /fake-indexeddb@4.0.2:
+    resolution: {integrity: sha512-SdTwEhnakbgazc7W3WUXOJfGmhH0YfG4d+dRPOFoYDRTL6U5t8tvrmkf2W/C3W1jk2ylV7Wrnj44RASqpX/lEw==}
+    dependencies:
+      realistic-structured-clone: 3.0.0
     dev: true
 
   /fast-deep-equal@3.1.3:
@@ -2424,6 +2444,10 @@ packages:
 
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+    dev: true
+
+  /lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
     dev: true
 
   /logform@2.5.1:
@@ -3033,6 +3057,14 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
+  /realistic-structured-clone@3.0.0:
+    resolution: {integrity: sha512-rOjh4nuWkAqf9PWu6JVpOWD4ndI+JHfgiZeMmujYcPi+fvILUu7g6l26TC1K5aBIp34nV+jE1cDO75EKOfHC5Q==}
+    dependencies:
+      domexception: 1.0.1
+      typeson: 6.1.0
+      typeson-registry: 1.0.0-alpha.39
+    dev: true
+
   /rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
     engines: {node: '>= 10.13.0'}
@@ -3405,6 +3437,13 @@ packages:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
     dev: true
 
+  /tr46@2.1.0:
+    resolution: {integrity: sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==}
+    engines: {node: '>=8'}
+    dependencies:
+      punycode: 2.3.0
+    dev: true
+
   /tr46@4.1.1:
     resolution: {integrity: sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==}
     engines: {node: '>=14'}
@@ -3465,6 +3504,20 @@ packages:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
     engines: {node: '>=14.17'}
     hasBin: true
+    dev: true
+
+  /typeson-registry@1.0.0-alpha.39:
+    resolution: {integrity: sha512-NeGDEquhw+yfwNhguLPcZ9Oj0fzbADiX4R0WxvoY8nGhy98IbzQy1sezjoEFWOywOboj/DWehI+/aUlRVrJnnw==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      base64-arraybuffer-es6: 0.7.0
+      typeson: 6.1.0
+      whatwg-url: 8.7.0
+    dev: true
+
+  /typeson@6.1.0:
+    resolution: {integrity: sha512-6FTtyGr8ldU0pfbvW/eOZrEtEkczHRUtduBnA90Jh9kMPCiFNnXIon3vF41N0S4tV1HHQt4Hk1j4srpESziCaA==}
+    engines: {node: '>=0.1.14'}
     dev: true
 
   /uglify-js@3.17.4:
@@ -3660,6 +3713,15 @@ packages:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
     dev: true
 
+  /webidl-conversions@4.0.2:
+    resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
+    dev: true
+
+  /webidl-conversions@6.1.0:
+    resolution: {integrity: sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==}
+    engines: {node: '>=10.4'}
+    dev: true
+
   /webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -3777,6 +3839,15 @@ packages:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+    dev: true
+
+  /whatwg-url@8.7.0:
+    resolution: {integrity: sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==}
+    engines: {node: '>=10'}
+    dependencies:
+      lodash: 4.17.21
+      tr46: 2.1.0
+      webidl-conversions: 6.1.0
     dev: true
 
   /which@2.0.2:

--- a/src/storage/indexeddb.ts
+++ b/src/storage/indexeddb.ts
@@ -1,0 +1,75 @@
+/** Represents an IndexedDB storage for Axios caching. */
+import { IDBPDatabase, openDB, wrap } from 'idb';
+import { BuildStorage, buildStorage } from './build';
+import { AxiosStorage, NotEmptyStorageValue, StorageValue } from './types';
+
+/**
+ * Creates an IndexedDB storage for Axios caching based on the provided IndexedDB database
+ * and store name.
+ *
+ * @param db - The IndexedDB database instance.
+ * @param storeName - The name of the IndexedDB object store to use.
+ * @returns A BuildStorage object representing the IndexedDB storage.
+ */
+function getIndexedDbStorage(db: IDBPDatabase<unknown>, storeName: string): BuildStorage {
+  return {
+    /**
+     * Finds and retrieves a value from the IndexedDB storage based on the provided key.
+     *
+     * @param key - The key used to retrieve the value.
+     * @returns A Promise that resolves to the retrieved value or undefined if not found.
+     */
+    async find(key: string): Promise<StorageValue | undefined> {
+      return await db.get(storeName, key).then((result: string | undefined) => {
+        if (result !== undefined) {
+          return JSON.parse(result) as StorageValue;
+        }
+        return undefined;
+      });
+    },
+
+    /**
+     * Sets a value in the IndexedDB storage based on the provided key and value.
+     *
+     * @param key - The key used to store the value.
+     * @param value - The value to store in the IndexedDB storage.
+     */
+    async set(key: string, value: NotEmptyStorageValue) {
+      await db.put(storeName, JSON.stringify(value), `axios-cache-${key}`);
+    },
+
+    /**
+     * Removes a value from the IndexedDB storage based on the provided key.
+     *
+     * @param key - The key used to remove the value.
+     * @returns A Promise that resolves when the value is successfully removed.
+     */
+    async remove(key: string) {
+      return await db.delete(storeName, `axios-cache-${key}`);
+    }
+  };
+}
+
+/**
+ * Creates and initializes an IndexedDB storage for Axios caching.
+ *
+ * @returns A Promise that resolves to an AxiosStorage object representing the IndexedDB
+ *   storage.
+ */
+export default async function buildIndexedDbStorage(
+  unwrappedDbObject: IDBDatabase | undefined = undefined
+): Promise<AxiosStorage> {
+  const storeName = 'axios-cache-interceptor-db';
+  let db: IDBPDatabase<unknown> | undefined = undefined;
+  if (unwrappedDbObject !== undefined) {
+    db = wrap(unwrappedDbObject);
+  } else {
+    db = await openDB(storeName, 1, {
+      upgrade(db) {
+        db.createObjectStore(storeName);
+      }
+    });
+  }
+
+  return buildStorage(getIndexedDbStorage(db, storeName));
+}

--- a/test/dom.ts
+++ b/test/dom.ts
@@ -4,3 +4,4 @@ const dom = new JSDOM(undefined, { url: 'https://axios-cache-interceptor.js.org'
 
 export const localStorage = dom.window.localStorage;
 export const sessionStorage = dom.window.sessionStorage;
+export const indexedDB = dom.window.indexedDB;

--- a/test/storage/indexeddb.test.ts
+++ b/test/storage/indexeddb.test.ts
@@ -4,7 +4,7 @@ import type { CachedStorageValue } from '../../src/storage/types';
 import { EMPTY_RESPONSE } from '../utils';
 import { testStorage } from './storages';
 import buildIndexedDbStorage from '../../src/storage/indexeddb';
-import { indexedDB } from '../dom';
+import "fake-indexeddb/auto";
 
 const INDEXED_DB_TEST_NAME = 'axios-cache-test-indexeddb';
 

--- a/test/storage/indexeddb.test.ts
+++ b/test/storage/indexeddb.test.ts
@@ -8,7 +8,7 @@ import "fake-indexeddb/auto";
 
 const INDEXED_DB_TEST_NAME = 'axios-cache-test-indexeddb';
 
-async function getTestIndexedDb() {
+function getTestIndexedDb() {
   let db: IDBDatabase | undefined = undefined;
   const request = indexedDB.open(INDEXED_DB_TEST_NAME, 1);
 
@@ -19,22 +19,15 @@ async function getTestIndexedDb() {
   request.onsuccess = () => {
     db = request.result;
   };
-  return await buildIndexedDbStorage(db as unknown as IDBDatabase);
-};
+  return buildIndexedDbStorage(db as unknown as IDBDatabase);
+}
 
-// Copied from the memory.test.ts file
-describe('IndexedDBStorage', async () => {
+describe('IndexedDBStorage', () => {
   afterEach(() => {
     indexedDB.deleteDatabase(INDEXED_DB_TEST_NAME);
   });
   
-  testStorage('IndexedDBStorage', await getTestIndexedDb());
-
-  // Expects that when a result returned by storage.get() has his inner properties updated,
-  // a new request to storage.get() should maintain the same value.
-  //
-  // https://github.com/arthurfiorette/axios-cache-interceptor/issues/163
-  it('not allow changes by value reference', async () => {
+  it('should not allow changes by value reference', async () => {
     const storage = await getTestIndexedDb();
 
     await storage.set('key', {
@@ -59,5 +52,11 @@ describe('IndexedDBStorage', async () => {
     assert.notEqual(result2, null);
     assert.equal(result2.state, 'cached');
     assert.equal(result2.data?.data, 'data');
+  });
+
+  // Fügen Sie hier den TestStorage-Test hinzu
+  it('should pass the testStorage test', async () => {
+    const storage = await getTestIndexedDb();
+    await testStorage('IndexedDBStorage', storage);
   });
 });

--- a/test/storage/indexeddb.test.ts
+++ b/test/storage/indexeddb.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert';
+import { afterEach, describe, it } from 'node:test';
+import type { CachedStorageValue } from '../../src/storage/types';
+import { EMPTY_RESPONSE } from '../utils';
+import { testStorage } from './storages';
+import buildIndexedDbStorage from '../../src/storage/indexeddb';
+import { indexedDB } from '../dom';
+
+const INDEXED_DB_TEST_NAME = 'axios-cache-test-indexeddb';
+
+async function getTestIndexedDb() {
+  let db: IDBDatabase | undefined = undefined;
+  const request = indexedDB.open(INDEXED_DB_TEST_NAME, 1);
+
+  request.onerror = (error) => {
+    throw new Error(`Error opening IndexedDB database ${error}`);
+  };
+
+  request.onsuccess = () => {
+    db = request.result;
+  };
+  return await buildIndexedDbStorage(db as unknown as IDBDatabase);
+};
+
+// Copied from the memory.test.ts file
+describe('IndexedDBStorage', async () => {
+  afterEach(() => {
+    indexedDB.deleteDatabase(INDEXED_DB_TEST_NAME);
+  });
+  
+  testStorage('IndexedDBStorage', await getTestIndexedDb());
+
+  // Expects that when a result returned by storage.get() has his inner properties updated,
+  // a new request to storage.get() should maintain the same value.
+  //
+  // https://github.com/arthurfiorette/axios-cache-interceptor/issues/163
+  it('not allow changes by value reference', async () => {
+    const storage = await getTestIndexedDb();
+
+    await storage.set('key', {
+      state: 'cached',
+      createdAt: Date.now(),
+      ttl: 1000 * 60 * 5, // 5 Minutes
+      data: { ...EMPTY_RESPONSE, data: 'data' }
+    });
+
+    const result = (await storage.get('key')) as CachedStorageValue;
+
+    assert.notEqual(result, null);
+    assert.equal(result.state, 'cached');
+    assert.equal(result.data.data, 'data');
+
+    // Deletes the value
+    delete result.data.data;
+
+    // Check if the value has been modified
+    const result2 = await storage.get('key');
+
+    assert.notEqual(result2, null);
+    assert.equal(result2.state, 'cached');
+    assert.equal(result2.data?.data, 'data');
+  });
+});


### PR DESCRIPTION
This pull request introduces an IndexedDB storage implementation for Axios caching. IndexedDB provides a client-side storage solution that can be used to store and retrieve data for efficient caching of Axios requests.

Key Changes:

Added a new module for IndexedDB-based storage.

- Created functions for finding, setting, and removing data from IndexedDB storage.
- Initialized an IndexedDB database and object store for Axios caching.
- Integrated the IndexedDB storage into the Axios caching system.

Code Highlights:

- **getIndexedDbStorage(db: IDBPDatabase<unknown>, storeName: string): BuildStorage**: This function creates an IndexedDB storage object for Axios caching. It includes methods for finding, setting, and removing data based on the provided IndexedDB database and store name.
- **buildIndexedDbStorage(): Promise<AxiosStorage>**: This function initializes the IndexedDB storage by creating the necessary object store and returns an AxiosStorage object, which can be used for caching Axios requests.

Note:

- Since the indexed is only available in browsers, no tests can be designed for this storage without mocking.
- Due to the nature of the IndexedDB interface, a web API was not possible because of asynchrony.