### PR TITLE
Update documentation to clarify side effects of setupCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ overloading the network or coding himself a simple and buggy cache system.
 import Axios from 'axios';
 import { setupCache } from 'axios-cache-interceptor';
 
-// Same object, new types. All Axios imports in your project will now have the cache interceptor.
-const axios = setupCache(Axios);
+const instance = Axios.create();
+const axios = setupCache(instance);
 
 const req1 = axios.get('https://arthur.place/');
 const req2 = axios.get('https://arthur.place/');

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ overloading the network or coding himself a simple and buggy cache system.
 import Axios from 'axios';
 import { setupCache } from 'axios-cache-interceptor';
 
-// Same object, new types.
+// Same object, new types. All Axios imports in your project will now have the cache interceptor.
 const axios = setupCache(Axios);
 
 const req1 = axios.get('https://arthur.place/');

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -1,11 +1,10 @@
 # setupCache()
 
 The `setupCache` function receives the axios instance and a set of optional properties
-described below. They are used and shared by the entire application workflow.
-This means that other imports of axios will also have the cache interceptor.
+described below. This modifies the axios instance in place and returns it.
 
 ```ts
-const axios = setupCache(axios, OPTIONS);
+const axios = setupCache(axiosInstance, OPTIONS);
 ```
 
 ::: tip
@@ -18,13 +17,12 @@ the defaults for all requests.
 
 ::: tip
 
-If you do not want to override the default axios instance, you can fist create a new one and
-then pass it to the `setupCache` function. Then, just use this new separate instance for any requests
-you want to use the cache interceptor with.
+If you want to use the same cache interceptor for all your axios instances, you can
+call `setupCache` with the default axios instance.
 
 ```ts
-const axios = Axios.create();
-setupCache(axios, OPTIONS);
+import Axios from 'axios';
+setupCache(Axios, OPTIONS);
 ```
 
 :::
@@ -179,15 +177,15 @@ Read the [Debugging](./guide/debugging.md) page for the complete guide.
 
 ```ts
 // Will print debug info in the console.
-setupCache(axios, { debug: console.log });
+setupCache(axiosInstance, { debug: console.log });
 
 // Own logging platform.
-setupCache(axios, {
+setupCache(axiosInstance, {
   debug: ({ id, msg, data }) => myLoggerExample.emit({ id, msg, data })
 });
 
 // Disables debug. (default)
-setupCache(axios, { debug: undefined });
+setupCache(axiosInstance, { debug: undefined });
 ```
 
 :::

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -2,6 +2,7 @@
 
 The `setupCache` function receives the axios instance and a set of optional properties
 described below. They are used and shared by the entire application workflow.
+This means that other imports of axios will also have the cache interceptor.
 
 ```ts
 const axios = setupCache(axios, OPTIONS);
@@ -12,6 +13,19 @@ const axios = setupCache(axios, OPTIONS);
 The `setupCache` function receives global options and all
 [request specifics](./config/request-specifics.md) ones too. This way, you can customize
 the defaults for all requests.
+
+:::
+
+::: tip
+
+If you do not want to override the default axios instance, you can fist create a new one and
+then pass it to the `setupCache` function. Then, just use this new separate instance for any requests
+you want to use the cache interceptor with.
+
+```ts
+const axios = Axios.create();
+setupCache(axios, OPTIONS);
+```
 
 :::
 

--- a/docs/src/guide/getting-started.md
+++ b/docs/src/guide/getting-started.md
@@ -50,7 +50,8 @@ instance, as shown below:
 import Axios from 'axios';
 import { setupCache } from 'axios-cache-interceptor';
 
-// same object, but with updated typings.
+// Same object, new types. 
+// All Axios imports in your project will now have the cache interceptor.
 const axios = setupCache(Axios); // [!code focus]
 
 const req1 = axios.get('https://api.example.com/'); // [!code focus]
@@ -66,7 +67,8 @@ res2.cached; // true // [!code focus]
 const Axios = require('axios');
 const { setupCache } = require('axios-cache-interceptor');
 
-// same object, but with updated typings.
+// Same object, new types. 
+// All Axios imports in your project will now have the cache interceptor.
 const axios = setupCache(Axios); // [!code focus]
 
 const req1 = axios.get('https://api.example.com/'); // [!code focus]
@@ -82,7 +84,8 @@ res2.cached; // true // [!code focus]
 const Axios = window.axios;
 const { setupCache } = window.AxiosCacheInterceptor;
 
-// same object, but with updated typings.
+// Same object, new types. 
+// Overrides window.axios everywhere in the project.
 const axios = setupCache(Axios); // [!code focus]
 
 const req1 = axios.get('https://api.example.com/'); // [!code focus]
@@ -98,7 +101,7 @@ res2.cached; // true // [!code focus]
 import Axios from 'https://cdn.skypack.dev/axios';
 import { setupCache } from 'https://cdn.skypack.dev/axios-cache-interceptor';
 
-// same object, but with updated typings.
+// Same object, new types. 
 const axios = setupCache(Axios); // [!code focus]
 
 const req1 = axios.get('https://api.example.com/'); // [!code focus]

--- a/docs/src/guide/getting-started.md
+++ b/docs/src/guide/getting-started.md
@@ -50,9 +50,9 @@ instance, as shown below:
 import Axios from 'axios';
 import { setupCache } from 'axios-cache-interceptor';
 
-// Same object, new types. 
-// All Axios imports in your project will now have the cache interceptor.
-const axios = setupCache(Axios); // [!code focus]
+const instance = Axios.create(); // [!code focus]
+const axios = setupCache(instance);// [!code focus]
+
 
 const req1 = axios.get('https://api.example.com/'); // [!code focus]
 const req2 = axios.get('https://api.example.com/'); // [!code focus]
@@ -67,9 +67,8 @@ res2.cached; // true // [!code focus]
 const Axios = require('axios');
 const { setupCache } = require('axios-cache-interceptor');
 
-// Same object, new types. 
-// All Axios imports in your project will now have the cache interceptor.
-const axios = setupCache(Axios); // [!code focus]
+const instance = Axios.create(); // [!code focus]
+const axios = setupCache(instance);// [!code focus]
 
 const req1 = axios.get('https://api.example.com/'); // [!code focus]
 const req2 = axios.get('https://api.example.com/'); // [!code focus]
@@ -84,9 +83,8 @@ res2.cached; // true // [!code focus]
 const Axios = window.axios;
 const { setupCache } = window.AxiosCacheInterceptor;
 
-// Same object, new types. 
-// Overrides window.axios everywhere in the project.
-const axios = setupCache(Axios); // [!code focus]
+const instance = Axios.create(); // [!code focus]
+const axios = setupCache(instance);// [!code focus]
 
 const req1 = axios.get('https://api.example.com/'); // [!code focus]
 const req2 = axios.get('https://api.example.com/'); // [!code focus]
@@ -101,8 +99,9 @@ res2.cached; // true // [!code focus]
 import Axios from 'https://cdn.skypack.dev/axios';
 import { setupCache } from 'https://cdn.skypack.dev/axios-cache-interceptor';
 
-// Same object, new types. 
-const axios = setupCache(Axios); // [!code focus]
+
+const instance = Axios.create(); // [!code focus]
+const axios = setupCache(instance);// [!code focus]
 
 const req1 = axios.get('https://api.example.com/'); // [!code focus]
 const req2 = axios.get('https://api.example.com/'); // [!code focus]


### PR DESCRIPTION
# Key Changes:

Update documentation to clarify that using `setupCache` on the default axios import or on `window.axios` will apply the cache interceptor everywhere that default export instance is used. 

# Reason for change:

Adds necessary clarification so that the end user has full knowledge of the consequences of invoking setupCache on the default export. For those who are not very familiar with JS or axios, such a clarification could help them avoid unwanted caching of data. 

Such unwanted caching can be even more problematic when resources are not uniquely identified by their URL and instead distinguished through headers (it's a bad practice but it is a practice nonetheless), which can lead even to sharing of data between users for instance.

This is by no means a fault of this library but one of the end user, but still, if we can help the user avoid such a situation, why not? 😃 


