### PR TITLE
if a transformresponse function is used, it has some unintended side effect

### DIFF
--- a/src/interceptors/request.ts
+++ b/src/interceptors/request.ts
@@ -214,6 +214,11 @@ export function defaultRequestInterceptor(axios: AxiosCacheInstance) {
       cachedResponse = cache.data;
     }
 
+    // The cached data is already transformed after receiving the response from the server. 
+    // Reapplying the transformation on the transformed data will have an unintended effect. 
+    // Since the cached data is already in the desired format, there is no need to apply the transformation function again.
+    config.transformResponse = undefined;
+
     // Even though the response interceptor receives this one from here,
     // it has been configured to ignore cached responses = true
     config.adapter = function cachedAdapter(): Promise<CacheAxiosResponse> {

--- a/src/interceptors/request.ts
+++ b/src/interceptors/request.ts
@@ -214,8 +214,8 @@ export function defaultRequestInterceptor(axios: AxiosCacheInstance) {
       cachedResponse = cache.data;
     }
 
-    // The cached data is already transformed after receiving the response from the server. 
-    // Reapplying the transformation on the transformed data will have an unintended effect. 
+    // The cached data is already transformed after receiving the response from the server.
+    // Reapplying the transformation on the transformed data will have an unintended effect.
     // Since the cached data is already in the desired format, there is no need to apply the transformation function again.
     config.transformResponse = undefined;
 

--- a/test/interceptors/request.test.ts
+++ b/test/interceptors/request.test.ts
@@ -354,6 +354,25 @@ describe('Request Interceptor', () => {
     assert.equal(headers2[Header.Expires], undefined);
   });
 
+  it('ensure cached data is not transformed', async () => {
+    const axios = mockAxios();
+
+    // data will transformed with first request
+    const res1 = await axios.get('url', {
+      transformResponse: (data: unknown) => [data]
+    });
+
+    assert.notEqual(res1.config.transformResponse, undefined);
+
+    // cached data should not transform the data as it is alread in desired format.
+    // transform function is nullified in this scenario
+    const res2 = await axios.get('url', {
+      transformResponse: (data: unknown) => [data]
+    });
+
+    assert.equal(res2.config.transformResponse, undefined);
+  });
+
   it('ensures request with urls in exclude.paths are not cached', async () => {
     const axios = mockAxios({
       cachePredicate: {

--- a/test/interceptors/response.test.ts
+++ b/test/interceptors/response.test.ts
@@ -278,7 +278,7 @@ describe('Response Interceptor', () => {
       transformResponse: (data: unknown) => [data]
     });
 
-    // cached response 
+    // cached response
     // should not transform again as already in desired format
     const cachedResponse = await axios.get('url', {
       transformResponse: (data: unknown) => [data]

--- a/test/interceptors/response.test.ts
+++ b/test/interceptors/response.test.ts
@@ -273,13 +273,19 @@ describe('Response Interceptor', () => {
   it('Works when modifying response', async () => {
     const axios = mockAxios();
 
-    const normal = await axios.get('url');
-    const transformed = await axios.get('url', {
+    // fresh response from server and transformed
+    const freshResponse = await axios.get('url', {
       transformResponse: (data: unknown) => [data]
     });
 
-    assert.ok(normal.data);
-    assert.deepEqual(transformed.data, [true]);
+    // cached response 
+    // should not transform again as already in desired format
+    const cachedResponse = await axios.get('url', {
+      transformResponse: (data: unknown) => [data]
+    });
+
+    assert.deepEqual(freshResponse.data, [true]);
+    assert.deepEqual(cachedResponse.data, [true]);
   });
 
   it('Works when modifying the error response', async () => {


### PR DESCRIPTION
If we use a transformResponse function that transform the response entirely in different format than what is received from server, axios again apply the transform function on the  the already transformed response and it produce an undesired result.

This is related to discussion https://github.com/arthurfiorette/axios-cache-interceptor/discussions/771


<!--
Thank you for your pull request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
