### PR TITLE
docs: update cache jsdocs for debugging

### DIFF
--- a/src/cache/cache.ts
+++ b/src/cache/cache.ts
@@ -331,7 +331,7 @@ export interface CacheInstance {
    * the complete guide.
    *
    * @default noop function
-   * @see https://axios-cache-interceptor.js.org/#/pages/development-mode
+   * @see https://axios-cache-interceptor.js.org/guide/debugging
    */
   debug: (this: void, msg: DebugObject) => void;
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
This appears to be an old/incorrect link that just routes you to https://axios-cache-interceptor.js.org/ I think we want to use https://axios-cache-interceptor.js.org/guide/debugging instead