### PR TITLE
Prevent caching private responses server-side

### DIFF
--- a/src/header/interpreter.ts
+++ b/src/header/interpreter.ts
@@ -8,12 +8,18 @@ export const defaultHeaderInterpreter: HeaderInterpreter = (headers) => {
   const cacheControl: unknown = headers[Header.CacheControl];
 
   if (cacheControl) {
-    const { noCache, noStore, maxAge, maxStale, immutable, staleWhileRevalidate } = parse(
-      String(cacheControl)
-    );
+    const {
+      noCache,
+      noStore,
+      maxAge,
+      maxStale,
+      immutable,
+      staleWhileRevalidate,
+      private: _private
+    } = parse(String(cacheControl));
 
     // Header told that this response should not be cached.
-    if (noCache || noStore) {
+    if (noCache || noStore || (_private && typeof window === 'undefined')) {
       return 'dont cache';
     }
 

--- a/test/header/interpreter.test.ts
+++ b/test/header/interpreter.test.ts
@@ -44,6 +44,26 @@ describe('Header Interpreter', () => {
     assert.deepEqual(result, { cache: 1000 * 60 * 60 * 24 * 365 });
   });
 
+  it("Don't cache private, no-cache and no-store", () => {
+    const privateResult = defaultHeaderInterpreter({
+      [Header.CacheControl]: 'private'
+    });
+
+    assert.deepEqual(privateResult, 'dont cache');
+
+    const noCacheResult = defaultHeaderInterpreter({
+      [Header.CacheControl]: 'no-cache'
+    });
+
+    assert.deepEqual(noCacheResult, 'dont cache');
+
+    const noStoreResult = defaultHeaderInterpreter({
+      [Header.CacheControl]: 'no-store'
+    });
+
+    assert.deepEqual(noStoreResult, 'dont cache');
+  });
+
   it('MaxAge=10 and Age=3 and StaleWhileRevalidate Headers', () => {
     const result = defaultHeaderInterpreter({
       [Header.CacheControl]: 'max-age=10, stale-while-revalidate=5',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

When a server returns `private` in the cache-control header, you do not want to cache it unless on a private device like a browser.