### PR TITLE
fix: aborted requests should not clear its cache afterwards if previous request was cached (#922)

### DIFF
--- a/test/interceptors/response.test.ts
+++ b/test/interceptors/response.test.ts
@@ -361,4 +361,47 @@ describe('Response Interceptor', () => {
     assert.equal(storage.state, 'cached');
     assert.equal(storage.data?.data, true);
   });
+
+  // https://github.com/arthurfiorette/axios-cache-interceptor/issues/922
+  it('Aborted requests should preserve non-stale valid cache entries', async () => {
+    const instance = Axios.create({});
+    const axios = setupCache(instance, {});
+
+    const id = '1';
+
+    const cache = {
+      data: true,
+      headers: {},
+      status: 200,
+      statusText: 'Ok'
+    };
+
+    // Cache request
+    axios.storage.set(id, {
+      state: 'cached',
+      ttl: 5000,
+      createdAt: Date.now(),
+      data: cache
+    });
+
+    // First request cancelled immediately
+    const controller = new AbortController();
+    const cancelled = axios.get('http://unknown.url.lan:1234', { id, signal: controller.signal });
+    controller.abort();
+    try {
+      await cancelled;
+      assert.fail('should have thrown an error');
+    } catch (error: any) {
+      assert.equal(error.code, 'ERR_CANCELED');
+    }
+
+    // Second request cancelled after a macrotask
+    const controller2 = new AbortController();
+    const promise = axios.get('http://unknown.url.lan:1234', { id, signal: controller2.signal });
+    // Wait for eventual request to be sent
+    await new Promise((res) => setTimeout(res));
+    controller2.abort();
+    const response = await promise;
+    assert.ok(response.cached);
+  });
 });


### PR DESCRIPTION
I'm not super convinced with the quality of the fix, but since it's a special case, maybe it's okay like that.

Ref: https://github.com/arthurfiorette/axios-cache-interceptor/issues/922

<!--
Thank you for your pull request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
