### PR TITLE
Feature: whitelist paths

### DIFF
--- a/docs/src/config/request-specifics.md
+++ b/docs/src/config/request-specifics.md
@@ -182,8 +182,10 @@ exceptions to the method rule.
   _(These default status codes follows RFC 7231)_
 
 An object or function that will be tested against the response to indicate if it can be
-cached. You can use `statusCheck`, `containsHeader`, `ignoreUrls` and `responseMatch` to test against
+cached. You can use `statusCheck`, `containsHeader`, `ignoreUrls`, `whitelistedUrls` and `responseMatch` to test against
 the response.
+
+If both `ignoreUrls` & `whitelistedUrls` are matched, `ignoreUrls` take precidence.
 
 ```ts{5,8,13}
 axios.get<{ auth: { status: string } }>('url', {
@@ -205,6 +207,9 @@ axios.get<{ auth: { status: string } }>('url', {
 
       // Ensures no request is cached if its url starts with "/api"
       ignoreUrls: [/^\/api/]
+
+      // only cache request urls that includes "weekly"
+      whitelistedUrls: ['weekly']
     }
   }
 });

--- a/docs/src/config/request-specifics.md
+++ b/docs/src/config/request-specifics.md
@@ -182,10 +182,10 @@ exceptions to the method rule.
   _(These default status codes follows RFC 7231)_
 
 An object or function that will be tested against the response to indicate if it can be
-cached. You can use `statusCheck`, `containsHeader`, `ignoreUrls`, `whitelistedUrls` and `responseMatch` to test against
+cached. You can use `statusCheck`, `containsHeader`, `ignoreUrls`, `allowUrls` and `responseMatch` to test against
 the response.
 
-If both `ignoreUrls` & `whitelistedUrls` are matched, `ignoreUrls` take precidence.
+If both `ignoreUrls` & `allowUrls` are matched, `ignoreUrls` take precedence.
 
 ```ts{5,8,13}
 axios.get<{ auth: { status: string } }>('url', {
@@ -209,7 +209,7 @@ axios.get<{ auth: { status: string } }>('url', {
       ignoreUrls: [/^\/api/]
 
       // only cache request urls that includes "weekly"
-      whitelistedUrls: ['weekly']
+      allowUrls: ['weekly']
     }
   }
 });

--- a/src/interceptors/request.ts
+++ b/src/interceptors/request.ts
@@ -3,7 +3,6 @@ import type { AxiosCacheInstance, CacheAxiosResponse } from '../cache/axios.js';
 import { Header } from '../header/headers.js';
 import type { CachedResponse, CachedStorageValue, LoadingStorageValue } from '../storage/types.js';
 import { regexOrStringMatch } from '../util/cache-predicate.js';
-import type { CachePredicateObject } from '../util/types.js';
 import type { RequestInterceptor } from './build.js';
 import {
   type ConfigWithCache,
@@ -63,32 +62,35 @@ export function defaultRequestInterceptor(axios: AxiosCacheInstance): RequestInt
     ) {
       let matched = false;
 
-      function logDebug(matched: boolean, cachePredicate: CachePredicateObject) {
-        if (__ACI_DEV__) {
-          axios.debug({
-            id: config.id,
-            msg: `${matched ? 'Cached' : 'Ignored'} because url (${config.url}) ${matched ? 'matches' : 'does not match any'} allowUrls (${cachePredicate.allowUrls})`,
-            data: {
-              url: config.url,
-              cachePredicate: cachePredicate
-            }
-          });
-        }
-      }
-
       for (const url of config.cache.cachePredicate.allowUrls) {
         if (regexOrStringMatch(url, config.url)) {
           matched = true;
 
-          logDebug(matched, config.cache.cachePredicate);
-
+          if (__ACI_DEV__) {
+            axios.debug({
+              id: config.id,
+              msg: `Cached because url (${config.url}) matches allowUrls (${config.cache.cachePredicate.allowUrls})`,
+              data: {
+                url: config.url,
+                cachePredicate: config.cache.cachePredicate
+              }
+            });
+          }
           break;
         }
       }
 
       if (!matched) {
-        logDebug(matched, config.cache.cachePredicate);
-
+        if (__ACI_DEV__) {
+          axios.debug({
+            id: config.id,
+            msg: `Ignored because url (${config.url}) does not match any allowUrls (${config.cache.cachePredicate.allowUrls})`,
+            data: {
+              url: config.url,
+              cachePredicate: config.cache.cachePredicate
+            }
+          });
+        }
         return config;
       }
     }

--- a/src/util/cache-predicate.ts
+++ b/src/util/cache-predicate.ts
@@ -35,3 +35,11 @@ export async function testCachePredicate<R = unknown, D = unknown>(
 
   return true;
 }
+
+export function regexOrStringMatch(matchPattern: string | RegExp, configUrl: string) {
+  return matchPattern instanceof RegExp
+    ? // Handles stateful regexes
+      // biome-ignore lint: reduces the number of checks
+      ((matchPattern.lastIndex = 0), matchPattern.test(configUrl))
+    : configUrl.includes(matchPattern);
+}

--- a/src/util/cache-predicate.ts
+++ b/src/util/cache-predicate.ts
@@ -36,10 +36,20 @@ export async function testCachePredicate<R = unknown, D = unknown>(
   return true;
 }
 
+/**
+ * Determines whether a given URL matches a specified pattern, which can be either a string or a regular expression.
+ *
+ * @param matchPattern - The pattern to match against
+ *   - If it's a regular expression, it will be reset to ensure consistent behavior for stateful regular expressions.
+ *   - If it's a string, the function checks if the URL contains the string.
+ * @param configUrl - The URL to test against the provided pattern; normally `config.url`.
+ * @returns `true` if the `configUrl` matches the `matchPattern`
+ */
 export function regexOrStringMatch(matchPattern: string | RegExp, configUrl: string) {
-  return matchPattern instanceof RegExp
-    ? // Handles stateful regexes
-      // biome-ignore lint: reduces the number of checks
-      ((matchPattern.lastIndex = 0), matchPattern.test(configUrl))
-    : configUrl.includes(matchPattern);
+  if (matchPattern instanceof RegExp) {
+    matchPattern.lastIndex = 0; // Reset the regex to ensure consistent matching
+    return matchPattern.test(configUrl);
+  }
+
+  return configUrl.includes(matchPattern);
 }

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -48,9 +48,9 @@ export interface CachePredicateObject<R = unknown, D = unknown> {
    *
    * - It checks against the `request.url` property, `baseURL` is not considered.
    * - When only `baseURL` is specified, this property is ignored.
-   * - If both `ignoreUrls` & `whitelistedUrls` are matched, `ignoreUrls` take precidence.
+   * - If both `ignoreUrls` & `allowUrls` are matched, `ignoreUrls` take precedence.
    */
-  whitelistedUrls?: (RegExp | string)[];
+  allowUrls?: (RegExp | string)[];
 }
 
 /**

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -42,6 +42,15 @@ export interface CachePredicateObject<R = unknown, D = unknown> {
    * - When only `baseURL` is specified, this property is ignored.
    */
   ignoreUrls?: (RegExp | string)[];
+
+  /**
+   * Ignores the request if their url does not match any provided urls and/or regexes.
+   *
+   * - It checks against the `request.url` property, `baseURL` is not considered.
+   * - When only `baseURL` is specified, this property is ignored.
+   * - If both `ignoreUrls` & `whitelistedUrls` are matched, `ignoreUrls` take precidence.
+   */
+  whitelistedUrls?: (RegExp | string)[];
 }
 
 /**

--- a/test/interceptors/request.test.ts
+++ b/test/interceptors/request.test.ts
@@ -424,28 +424,6 @@ describe('Request Interceptor', () => {
     assert.equal(req3.stale, false);
   });
 
-  it('ensures request with urls in whitelistedUrls are cached', async () => {
-    const axios = mockAxios({
-      cachePredicate: {
-        whitelistedUrls: ['cache']
-      }
-    });
-
-    const [req0, req1] = await Promise.all([axios.get('url'), axios.get('url')]);
-
-    assert.equal(req0.cached, false);
-    assert.equal(req0.stale, undefined);
-    assert.equal(req1.cached, false);
-    assert.equal(req1.stale, undefined);
-
-    const [req2, req3] = await Promise.all([axios.get('cache-url'), axios.get('cache-url')]);
-
-    assert.equal(req2.cached, false);
-    assert.equal(req2.stale, undefined);
-    assert.ok(req3.cached);
-    assert.equal(req3.stale, false);
-  });
-
   it('ensures request with urls in exclude.paths are not cached (regex)', async () => {
     const axios = mockAxios({
       cachePredicate: {
@@ -475,10 +453,32 @@ describe('Request Interceptor', () => {
     assert.equal(req5.stale, undefined);
   });
 
-  it('ensures request with urls in whitelistedUrls are cached (regex)', async () => {
+  it('ensures request with urls in allowUrls are cached', async () => {
     const axios = mockAxios({
       cachePredicate: {
-        whitelistedUrls: [/keep/]
+        allowUrls: ['keep']
+      }
+    });
+
+    const [req0, req1] = await Promise.all([axios.get('url'), axios.get('url')]);
+
+    assert.equal(req0.cached, false);
+    assert.equal(req0.stale, undefined);
+    assert.equal(req1.cached, false);
+    assert.equal(req1.stale, undefined);
+
+    const [req2, req3] = await Promise.all([axios.get('keep-url'), axios.get('keep-url')]);
+
+    assert.equal(req2.cached, false);
+    assert.equal(req2.stale, undefined);
+    assert.ok(req3.cached);
+    assert.equal(req3.stale, false);
+  });
+
+  it('ensures request with urls in allowUrls are cached (regex)', async () => {
+    const axios = mockAxios({
+      cachePredicate: {
+        allowUrls: [/keep/]
       }
     });
 
@@ -504,34 +504,112 @@ describe('Request Interceptor', () => {
     assert.equal(req5.stale, false);
   });
 
-  it('ensures request with urls matching ignoreUrls and whitelistedUrls are not cached (regex)', async () => {
+  it('ensures request with urls matching ignoreUrls and allowUrls are not cached', async () => {
     const axios = mockAxios({
       cachePredicate: {
-        ignoreUrls: ['url'],
-        whitelistedUrls: [/keep/]
+        ignoreUrls: ['ignore'],
+        allowUrls: ['keep']
       }
     });
 
-    const [req0, req1] = await Promise.all([axios.get('my/url'), axios.get('my/url')]);
+    const [req0, req1] = await Promise.all([axios.get('ignore/link'), axios.get('ignore/link')]);
 
     assert.equal(req0.cached, false);
     assert.equal(req0.stale, undefined);
     assert.equal(req1.cached, false);
     assert.equal(req1.stale, undefined);
 
-    const [req2, req3] = await Promise.all([axios.get('keep-url'), axios.get('keep-url')]);
+    const [req2, req3] = await Promise.all([axios.get('keep/link'), axios.get('keep/link')]);
 
     assert.equal(req2.cached, false);
     assert.equal(req2.stale, undefined);
-    assert.equal(req3.cached, false);
-    assert.equal(req3.stale, undefined);
+    assert.ok(req3.cached);
+    assert.equal(req3.stale, false);
 
-    const [req4, req5] = await Promise.all([axios.get('keep-link'), axios.get('keep-link')]);
+    const [req4, req5] = await Promise.all([axios.get('keep/ignore'), axios.get('keep/ignore')]);
 
     assert.equal(req4.cached, false);
     assert.equal(req4.stale, undefined);
-    assert.ok(req5.cached);
-    assert.equal(req5.stale, false);
+    assert.equal(req5.cached, false);
+    assert.equal(req5.stale, undefined);
+
+    const [req6, req7] = await Promise.all([
+      axios.get('ignore/ignore'),
+      axios.get('ignore/ignore')
+    ]);
+
+    assert.equal(req6.cached, false);
+    assert.equal(req6.stale, undefined);
+    assert.equal(req7.cached, false);
+    assert.equal(req7.stale, undefined);
+
+    const [req8, req9] = await Promise.all([axios.get('ignore/keep'), axios.get('ignore/keep')]);
+
+    assert.equal(req8.cached, false);
+    assert.equal(req8.stale, undefined);
+    assert.equal(req9.cached, false);
+    assert.equal(req9.stale, undefined);
+
+    const [req10, req11] = await Promise.all([axios.get('keep/keep'), axios.get('keep/keep')]);
+
+    assert.equal(req10.cached, false);
+    assert.equal(req10.stale, undefined);
+    assert.ok(req11.cached);
+    assert.equal(req11.stale, false);
+  });
+
+  it('ensures request with urls matching ignoreUrls and allowUrls are not cached (regex)', async () => {
+    const axios = mockAxios({
+      cachePredicate: {
+        ignoreUrls: [/ignore/],
+        allowUrls: [/keep/]
+      }
+    });
+
+    const [req0, req1] = await Promise.all([axios.get('ignore/link'), axios.get('ignore/link')]);
+
+    assert.equal(req0.cached, false);
+    assert.equal(req0.stale, undefined);
+    assert.equal(req1.cached, false);
+    assert.equal(req1.stale, undefined);
+
+    const [req2, req3] = await Promise.all([axios.get('keep/link'), axios.get('keep/link')]);
+
+    assert.equal(req2.cached, false);
+    assert.equal(req2.stale, undefined);
+    assert.ok(req3.cached);
+    assert.equal(req3.stale, false);
+
+    const [req4, req5] = await Promise.all([axios.get('keep/ignore'), axios.get('keep/ignore')]);
+
+    assert.equal(req4.cached, false);
+    assert.equal(req4.stale, undefined);
+    assert.equal(req5.cached, false);
+    assert.equal(req5.stale, undefined);
+
+    const [req6, req7] = await Promise.all([
+      axios.get('ignore/ignore'),
+      axios.get('ignore/ignore')
+    ]);
+
+    assert.equal(req6.cached, false);
+    assert.equal(req6.stale, undefined);
+    assert.equal(req7.cached, false);
+    assert.equal(req7.stale, undefined);
+
+    const [req8, req9] = await Promise.all([axios.get('ignore/keep'), axios.get('ignore/keep')]);
+
+    assert.equal(req8.cached, false);
+    assert.equal(req8.stale, undefined);
+    assert.equal(req9.cached, false);
+    assert.equal(req9.stale, undefined);
+
+    const [req10, req11] = await Promise.all([axios.get('keep/keep'), axios.get('keep/keep')]);
+
+    assert.equal(req10.cached, false);
+    assert.equal(req10.stale, undefined);
+    assert.ok(req11.cached);
+    assert.equal(req11.stale, false);
   });
 
   it('clone works with concurrent requests', async () => {

--- a/test/interceptors/request.test.ts
+++ b/test/interceptors/request.test.ts
@@ -424,6 +424,28 @@ describe('Request Interceptor', () => {
     assert.equal(req3.stale, false);
   });
 
+  it('ensures request with urls in whitelistedUrls are cached', async () => {
+    const axios = mockAxios({
+      cachePredicate: {
+        whitelistedUrls: ['cache']
+      }
+    });
+
+    const [req0, req1] = await Promise.all([axios.get('url'), axios.get('url')]);
+
+    assert.equal(req0.cached, false);
+    assert.equal(req0.stale, undefined);
+    assert.equal(req1.cached, false);
+    assert.equal(req1.stale, undefined);
+
+    const [req2, req3] = await Promise.all([axios.get('cache-url'), axios.get('cache-url')]);
+
+    assert.equal(req2.cached, false);
+    assert.equal(req2.stale, undefined);
+    assert.ok(req3.cached);
+    assert.equal(req3.stale, false);
+  });
+
   it('ensures request with urls in exclude.paths are not cached (regex)', async () => {
     const axios = mockAxios({
       cachePredicate: {
@@ -451,6 +473,65 @@ describe('Request Interceptor', () => {
     assert.equal(req4.stale, undefined);
     assert.equal(req5.cached, false);
     assert.equal(req5.stale, undefined);
+  });
+
+  it('ensures request with urls in whitelistedUrls are cached (regex)', async () => {
+    const axios = mockAxios({
+      cachePredicate: {
+        whitelistedUrls: [/keep/]
+      }
+    });
+
+    const [req0, req1] = await Promise.all([axios.get('my/url'), axios.get('my/url')]);
+
+    assert.equal(req0.cached, false);
+    assert.equal(req0.stale, undefined);
+    assert.equal(req1.cached, false);
+    assert.equal(req1.stale, undefined);
+
+    const [req2, req3] = await Promise.all([axios.get('keep-url'), axios.get('keep-url')]);
+
+    assert.equal(req2.cached, false);
+    assert.equal(req2.stale, undefined);
+    assert.ok(req3.cached);
+    assert.equal(req3.stale, false);
+
+    const [req4, req5] = await Promise.all([axios.get('keep/url'), axios.get('keep/url')]);
+
+    assert.equal(req4.cached, false);
+    assert.equal(req4.stale, undefined);
+    assert.ok(req5.cached);
+    assert.equal(req5.stale, false);
+  });
+
+  it('ensures request with urls matching ignoreUrls and whitelistedUrls are not cached (regex)', async () => {
+    const axios = mockAxios({
+      cachePredicate: {
+        ignoreUrls: ['url'],
+        whitelistedUrls: [/keep/]
+      }
+    });
+
+    const [req0, req1] = await Promise.all([axios.get('my/url'), axios.get('my/url')]);
+
+    assert.equal(req0.cached, false);
+    assert.equal(req0.stale, undefined);
+    assert.equal(req1.cached, false);
+    assert.equal(req1.stale, undefined);
+
+    const [req2, req3] = await Promise.all([axios.get('keep-url'), axios.get('keep-url')]);
+
+    assert.equal(req2.cached, false);
+    assert.equal(req2.stale, undefined);
+    assert.equal(req3.cached, false);
+    assert.equal(req3.stale, undefined);
+
+    const [req4, req5] = await Promise.all([axios.get('keep-link'), axios.get('keep-link')]);
+
+    assert.equal(req4.cached, false);
+    assert.equal(req4.stale, undefined);
+    assert.ok(req5.cached);
+    assert.equal(req5.stale, false);
   });
 
   it('clone works with concurrent requests', async () => {


### PR DESCRIPTION
## Changes
added a whitelist option similar to the one in https://github.com/arthurfiorette/axios-cache-interceptor/pull/754
added ability to whitelist some url paths so that data is cached only for them
## Description
url paths added in `allowUrls` are matched against current url. If current url matches with any whitelisted urls, then the response for that request is cached.

Closes https://github.com/arthurfiorette/axios-cache-interceptor/issues/1007