### PR TITLE
feat: add "cached" flag to config object for others interceptors

### DIFF
--- a/src/cache/axios.ts
+++ b/src/cache/axios.ts
@@ -87,6 +87,11 @@ export interface CacheRequestConfig<R = any, D = any> extends AxiosRequestConfig
    * @see https://axios-cache-interceptor.js.org/config/response-object#cache
    */
   cache?: false | Partial<CacheProperties<R, D>>;
+
+  /**
+   * A simple boolean indicating the others interceptors if the request will be cached.
+   */
+  cached?: boolean;
 }
 
 /** Cached version of type {@link InternalAxiosRequestConfig} */

--- a/src/interceptors/request.ts
+++ b/src/interceptors/request.ts
@@ -14,6 +14,7 @@ import {
 export function defaultRequestInterceptor(axios: AxiosCacheInstance): RequestInterceptor {
   const onFulfilled: RequestInterceptor['onFulfilled'] = async (config) => {
     config.id = axios.generateKey(config);
+    config.cached = false;
 
     if (config.cache === false) {
       if (__ACI_DEV__) {
@@ -304,6 +305,8 @@ export function defaultRequestInterceptor(axios: AxiosCacheInstance): RequestInt
         id: config.id!
       });
     };
+
+    config.cached = true;
 
     if (__ACI_DEV__) {
       axios.debug({


### PR DESCRIPTION
Add a `cached` flag to the config object, allowing the following interceptors (like logging) to know the request will be cached.

<!--
Thank you for your pull request! Please provide a brief description above and review the requirements below.

Bug fixes and new features should include tests.

By submitting this contribution, I certify that:

* (a) I created it entirely or have the right to submit it under the project's open source license.
* (b) If based on prior work, I have the right to submit it with modifications under the same or an allowed license.
* (c) If provided by someone else, they certified (a), (b), or (c), and I have not modified it.
* (d) I understand this contribution is public, and a record of it (including personal details I submit) may be maintained indefinitely and redistributed under the project's license.
-->
