### PR TITLE
fixed docs typo seconds -> milliseconds

### DIFF
--- a/docs/src/guide/storages.md
+++ b/docs/src/guide/storages.md
@@ -37,8 +37,8 @@ For long running processes, you can avoid memory leaks by using playing with the
 `cleanupInterval` option. And can reduce memory usage with `maxEntries`.
 
 ```ts
-import Axios from "axios";
-import { setupCache, buildMemoryStorage } from "axios-cache-interceptor";
+import Axios from 'axios';
+import { setupCache, buildMemoryStorage } from 'axios-cache-interceptor';
 
 setupCache(axios, {
   // You don't need to to that, as it is the default option.
@@ -46,7 +46,7 @@ setupCache(axios, {
     /* cloneData default=*/ false,
     /* cleanupInterval default=*/ false,
     /* maxEntries default=*/ false
-  ),
+  )
 });
 ```
 
@@ -213,9 +213,9 @@ Here is an example of how to use the `idb-keyval` library to create a storage th
 IndexedDB.
 
 ```ts
-import axios from "axios";
-import { buildStorage } from "axios-cache-interceptor";
-import { clear, del, get, set } from "idb-keyval";
+import axios from 'axios';
+import { buildStorage } from 'axios-cache-interceptor';
+import { clear, del, get, set } from 'idb-keyval';
 
 const indexedDbStorage = buildStorage({
   async find(key) {
@@ -234,7 +234,7 @@ const indexedDbStorage = buildStorage({
 
   async remove(key) {
     await del(key);
-  },
+  }
 });
 ```
 


### PR DESCRIPTION
Fixed minor typo in the docs under "Node Redis storage" saying seconds instead of milliseconds. Added underscore in big number for readability.

<!--
Thank you for your pull request! Please provide a brief description above and review the requirements below.

Bug fixes and new features should include tests.

By submitting this contribution, I certify that:

* (a) I created it entirely or have the right to submit it under the project's open source license.
* (b) If based on prior work, I have the right to submit it with modifications under the same or an allowed license.
* (c) If provided by someone else, they certified (a), (b), or (c), and I have not modified it.
* (d) I understand this contribution is public, and a record of it (including personal details I submit) may be maintained indefinitely and redistributed under the project's license.
-->
